### PR TITLE
Dedupe roads

### DIFF
--- a/Assets/Dedupes.meta
+++ b/Assets/Dedupes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 780cb78f99bace345b449d87bfdd1279
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dedupes/Ann Arbor.dedupe-meta-evaluation.json
+++ b/Assets/Dedupes/Ann Arbor.dedupe-meta-evaluation.json
@@ -1,0 +1,5 @@
+{
+    "pixelsInDedupedImage": 32448,
+    "pixelsInOriginalImage": 32448,
+    "aggregateAreaEliminatedRoads": 10716
+}

--- a/Assets/Dedupes/Ann Arbor.dedupe-meta-evaluation.json.meta
+++ b/Assets/Dedupes/Ann Arbor.dedupe-meta-evaluation.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f2bbe0d6908db2147ba38ced539c6d69
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Dedupes/Ann Arbor.dedupe.json
+++ b/Assets/Dedupes/Ann Arbor.dedupe.json
@@ -1,0 +1,3328 @@
+{
+    "Items": [
+        {
+            "pixelSize": 736,
+            "pixelUniqueContribution": 736,
+            "isBeingKept": true,
+            "roadId": 10703
+        },
+        {
+            "pixelSize": 736,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10894
+        },
+        {
+            "pixelSize": 551,
+            "pixelUniqueContribution": 551,
+            "isBeingKept": true,
+            "roadId": 9776
+        },
+        {
+            "pixelSize": 497,
+            "pixelUniqueContribution": 497,
+            "isBeingKept": true,
+            "roadId": 21101
+        },
+        {
+            "pixelSize": 497,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 21269
+        },
+        {
+            "pixelSize": 484,
+            "pixelUniqueContribution": 453,
+            "isBeingKept": true,
+            "roadId": 8932
+        },
+        {
+            "pixelSize": 477,
+            "pixelUniqueContribution": 477,
+            "isBeingKept": true,
+            "roadId": 10041
+        },
+        {
+            "pixelSize": 477,
+            "pixelUniqueContribution": 302,
+            "isBeingKept": true,
+            "roadId": 8628
+        },
+        {
+            "pixelSize": 410,
+            "pixelUniqueContribution": 410,
+            "isBeingKept": true,
+            "roadId": 9523
+        },
+        {
+            "pixelSize": 410,
+            "pixelUniqueContribution": 405,
+            "isBeingKept": true,
+            "roadId": 9910
+        },
+        {
+            "pixelSize": 404,
+            "pixelUniqueContribution": 404,
+            "isBeingKept": true,
+            "roadId": 10695
+        },
+        {
+            "pixelSize": 404,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9965
+        },
+        {
+            "pixelSize": 381,
+            "pixelUniqueContribution": 381,
+            "isBeingKept": true,
+            "roadId": 11644
+        },
+        {
+            "pixelSize": 348,
+            "pixelUniqueContribution": 348,
+            "isBeingKept": true,
+            "roadId": 11056
+        },
+        {
+            "pixelSize": 339,
+            "pixelUniqueContribution": 339,
+            "isBeingKept": true,
+            "roadId": 20901
+        },
+        {
+            "pixelSize": 338,
+            "pixelUniqueContribution": 338,
+            "isBeingKept": true,
+            "roadId": 9455
+        },
+        {
+            "pixelSize": 315,
+            "pixelUniqueContribution": 315,
+            "isBeingKept": true,
+            "roadId": 11069
+        },
+        {
+            "pixelSize": 311,
+            "pixelUniqueContribution": 311,
+            "isBeingKept": true,
+            "roadId": 8697
+        },
+        {
+            "pixelSize": 311,
+            "pixelUniqueContribution": 311,
+            "isBeingKept": true,
+            "roadId": 11138
+        },
+        {
+            "pixelSize": 310,
+            "pixelUniqueContribution": 310,
+            "isBeingKept": true,
+            "roadId": 9374
+        },
+        {
+            "pixelSize": 310,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9688
+        },
+        {
+            "pixelSize": 300,
+            "pixelUniqueContribution": 300,
+            "isBeingKept": true,
+            "roadId": 9081
+        },
+        {
+            "pixelSize": 300,
+            "pixelUniqueContribution": 300,
+            "isBeingKept": true,
+            "roadId": 10250
+        },
+        {
+            "pixelSize": 300,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10014
+        },
+        {
+            "pixelSize": 293,
+            "pixelUniqueContribution": 277,
+            "isBeingKept": true,
+            "roadId": 20073
+        },
+        {
+            "pixelSize": 291,
+            "pixelUniqueContribution": 290,
+            "isBeingKept": true,
+            "roadId": 21165
+        },
+        {
+            "pixelSize": 280,
+            "pixelUniqueContribution": 262,
+            "isBeingKept": true,
+            "roadId": 8814
+        },
+        {
+            "pixelSize": 248,
+            "pixelUniqueContribution": 233,
+            "isBeingKept": true,
+            "roadId": 9444
+        },
+        {
+            "pixelSize": 248,
+            "pixelUniqueContribution": 243,
+            "isBeingKept": true,
+            "roadId": 9627
+        },
+        {
+            "pixelSize": 246,
+            "pixelUniqueContribution": 246,
+            "isBeingKept": true,
+            "roadId": 9177
+        },
+        {
+            "pixelSize": 244,
+            "pixelUniqueContribution": 161,
+            "isBeingKept": true,
+            "roadId": 8497
+        },
+        {
+            "pixelSize": 242,
+            "pixelUniqueContribution": 225,
+            "isBeingKept": true,
+            "roadId": 11385
+        },
+        {
+            "pixelSize": 239,
+            "pixelUniqueContribution": 74,
+            "isBeingKept": false,
+            "roadId": 8650
+        },
+        {
+            "pixelSize": 239,
+            "pixelUniqueContribution": 218,
+            "isBeingKept": true,
+            "roadId": 9084
+        },
+        {
+            "pixelSize": 236,
+            "pixelUniqueContribution": 227,
+            "isBeingKept": true,
+            "roadId": 21500
+        },
+        {
+            "pixelSize": 235,
+            "pixelUniqueContribution": 195,
+            "isBeingKept": true,
+            "roadId": 9156
+        },
+        {
+            "pixelSize": 232,
+            "pixelUniqueContribution": 205,
+            "isBeingKept": true,
+            "roadId": 20612
+        },
+        {
+            "pixelSize": 232,
+            "pixelUniqueContribution": 229,
+            "isBeingKept": true,
+            "roadId": 21510
+        },
+        {
+            "pixelSize": 229,
+            "pixelUniqueContribution": 223,
+            "isBeingKept": true,
+            "roadId": 8584
+        },
+        {
+            "pixelSize": 229,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9251
+        },
+        {
+            "pixelSize": 225,
+            "pixelUniqueContribution": 209,
+            "isBeingKept": true,
+            "roadId": 10914
+        },
+        {
+            "pixelSize": 222,
+            "pixelUniqueContribution": 222,
+            "isBeingKept": true,
+            "roadId": 9881
+        },
+        {
+            "pixelSize": 222,
+            "pixelUniqueContribution": 222,
+            "isBeingKept": true,
+            "roadId": 11034
+        },
+        {
+            "pixelSize": 222,
+            "pixelUniqueContribution": 203,
+            "isBeingKept": true,
+            "roadId": 8735
+        },
+        {
+            "pixelSize": 222,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11839
+        },
+        {
+            "pixelSize": 220,
+            "pixelUniqueContribution": 199,
+            "isBeingKept": true,
+            "roadId": 9603
+        },
+        {
+            "pixelSize": 218,
+            "pixelUniqueContribution": 197,
+            "isBeingKept": true,
+            "roadId": 20947
+        },
+        {
+            "pixelSize": 218,
+            "pixelUniqueContribution": 218,
+            "isBeingKept": true,
+            "roadId": 21594
+        },
+        {
+            "pixelSize": 217,
+            "pixelUniqueContribution": 217,
+            "isBeingKept": true,
+            "roadId": 9495
+        },
+        {
+            "pixelSize": 216,
+            "pixelUniqueContribution": 216,
+            "isBeingKept": true,
+            "roadId": 21144
+        },
+        {
+            "pixelSize": 216,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 21697
+        },
+        {
+            "pixelSize": 213,
+            "pixelUniqueContribution": 213,
+            "isBeingKept": true,
+            "roadId": 9633
+        },
+        {
+            "pixelSize": 212,
+            "pixelUniqueContribution": 205,
+            "isBeingKept": true,
+            "roadId": 9265
+        },
+        {
+            "pixelSize": 212,
+            "pixelUniqueContribution": 121,
+            "isBeingKept": true,
+            "roadId": 8496
+        },
+        {
+            "pixelSize": 209,
+            "pixelUniqueContribution": 200,
+            "isBeingKept": true,
+            "roadId": 9272
+        },
+        {
+            "pixelSize": 209,
+            "pixelUniqueContribution": 199,
+            "isBeingKept": true,
+            "roadId": 21172
+        },
+        {
+            "pixelSize": 209,
+            "pixelUniqueContribution": 200,
+            "isBeingKept": true,
+            "roadId": 11330
+        },
+        {
+            "pixelSize": 207,
+            "pixelUniqueContribution": 200,
+            "isBeingKept": true,
+            "roadId": 21195
+        },
+        {
+            "pixelSize": 207,
+            "pixelUniqueContribution": 207,
+            "isBeingKept": true,
+            "roadId": 9492
+        },
+        {
+            "pixelSize": 207,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 20971
+        },
+        {
+            "pixelSize": 203,
+            "pixelUniqueContribution": 203,
+            "isBeingKept": true,
+            "roadId": 9191
+        },
+        {
+            "pixelSize": 201,
+            "pixelUniqueContribution": 201,
+            "isBeingKept": true,
+            "roadId": 8823
+        },
+        {
+            "pixelSize": 201,
+            "pixelUniqueContribution": 156,
+            "isBeingKept": true,
+            "roadId": 8878
+        },
+        {
+            "pixelSize": 200,
+            "pixelUniqueContribution": 193,
+            "isBeingKept": true,
+            "roadId": 8676
+        },
+        {
+            "pixelSize": 198,
+            "pixelUniqueContribution": 189,
+            "isBeingKept": true,
+            "roadId": 10507
+        },
+        {
+            "pixelSize": 198,
+            "pixelUniqueContribution": 189,
+            "isBeingKept": true,
+            "roadId": 19436
+        },
+        {
+            "pixelSize": 194,
+            "pixelUniqueContribution": 157,
+            "isBeingKept": true,
+            "roadId": 9371
+        },
+        {
+            "pixelSize": 191,
+            "pixelUniqueContribution": 186,
+            "isBeingKept": true,
+            "roadId": 21625
+        },
+        {
+            "pixelSize": 191,
+            "pixelUniqueContribution": 160,
+            "isBeingKept": true,
+            "roadId": 9209
+        },
+        {
+            "pixelSize": 185,
+            "pixelUniqueContribution": 178,
+            "isBeingKept": true,
+            "roadId": 8694
+        },
+        {
+            "pixelSize": 184,
+            "pixelUniqueContribution": 180,
+            "isBeingKept": true,
+            "roadId": 11724
+        },
+        {
+            "pixelSize": 184,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11419
+        },
+        {
+            "pixelSize": 184,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11322
+        },
+        {
+            "pixelSize": 184,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10099
+        },
+        {
+            "pixelSize": 183,
+            "pixelUniqueContribution": 183,
+            "isBeingKept": true,
+            "roadId": 22458
+        },
+        {
+            "pixelSize": 183,
+            "pixelUniqueContribution": 183,
+            "isBeingKept": true,
+            "roadId": 11398
+        },
+        {
+            "pixelSize": 181,
+            "pixelUniqueContribution": 181,
+            "isBeingKept": true,
+            "roadId": 9175
+        },
+        {
+            "pixelSize": 180,
+            "pixelUniqueContribution": 159,
+            "isBeingKept": true,
+            "roadId": 9506
+        },
+        {
+            "pixelSize": 178,
+            "pixelUniqueContribution": 161,
+            "isBeingKept": true,
+            "roadId": 9189
+        },
+        {
+            "pixelSize": 177,
+            "pixelUniqueContribution": 82,
+            "isBeingKept": false,
+            "roadId": 9774
+        },
+        {
+            "pixelSize": 175,
+            "pixelUniqueContribution": 173,
+            "isBeingKept": true,
+            "roadId": 10349
+        },
+        {
+            "pixelSize": 175,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11771
+        },
+        {
+            "pixelSize": 174,
+            "pixelUniqueContribution": 152,
+            "isBeingKept": true,
+            "roadId": 10369
+        },
+        {
+            "pixelSize": 172,
+            "pixelUniqueContribution": 172,
+            "isBeingKept": true,
+            "roadId": 21473
+        },
+        {
+            "pixelSize": 171,
+            "pixelUniqueContribution": 147,
+            "isBeingKept": true,
+            "roadId": 9488
+        },
+        {
+            "pixelSize": 168,
+            "pixelUniqueContribution": 162,
+            "isBeingKept": true,
+            "roadId": 20945
+        },
+        {
+            "pixelSize": 168,
+            "pixelUniqueContribution": 147,
+            "isBeingKept": true,
+            "roadId": 11784
+        },
+        {
+            "pixelSize": 167,
+            "pixelUniqueContribution": 162,
+            "isBeingKept": true,
+            "roadId": 9590
+        },
+        {
+            "pixelSize": 164,
+            "pixelUniqueContribution": 145,
+            "isBeingKept": true,
+            "roadId": 21071
+        },
+        {
+            "pixelSize": 163,
+            "pixelUniqueContribution": 163,
+            "isBeingKept": true,
+            "roadId": 9337
+        },
+        {
+            "pixelSize": 162,
+            "pixelUniqueContribution": 59,
+            "isBeingKept": false,
+            "roadId": 9563
+        },
+        {
+            "pixelSize": 162,
+            "pixelUniqueContribution": 59,
+            "isBeingKept": false,
+            "roadId": 8586
+        },
+        {
+            "pixelSize": 159,
+            "pixelUniqueContribution": 122,
+            "isBeingKept": true,
+            "roadId": 11301
+        },
+        {
+            "pixelSize": 159,
+            "pixelUniqueContribution": 159,
+            "isBeingKept": true,
+            "roadId": 9361
+        },
+        {
+            "pixelSize": 158,
+            "pixelUniqueContribution": 158,
+            "isBeingKept": true,
+            "roadId": 9096
+        },
+        {
+            "pixelSize": 158,
+            "pixelUniqueContribution": 140,
+            "isBeingKept": true,
+            "roadId": 10130
+        },
+        {
+            "pixelSize": 157,
+            "pixelUniqueContribution": 101,
+            "isBeingKept": true,
+            "roadId": 22901
+        },
+        {
+            "pixelSize": 153,
+            "pixelUniqueContribution": 135,
+            "isBeingKept": true,
+            "roadId": 21559
+        },
+        {
+            "pixelSize": 152,
+            "pixelUniqueContribution": 144,
+            "isBeingKept": true,
+            "roadId": 21320
+        },
+        {
+            "pixelSize": 151,
+            "pixelUniqueContribution": 140,
+            "isBeingKept": true,
+            "roadId": 9436
+        },
+        {
+            "pixelSize": 149,
+            "pixelUniqueContribution": 141,
+            "isBeingKept": true,
+            "roadId": 21757
+        },
+        {
+            "pixelSize": 148,
+            "pixelUniqueContribution": 144,
+            "isBeingKept": true,
+            "roadId": 9146
+        },
+        {
+            "pixelSize": 143,
+            "pixelUniqueContribution": 121,
+            "isBeingKept": true,
+            "roadId": 10394
+        },
+        {
+            "pixelSize": 143,
+            "pixelUniqueContribution": 52,
+            "isBeingKept": false,
+            "roadId": 8903
+        },
+        {
+            "pixelSize": 143,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11289
+        },
+        {
+            "pixelSize": 141,
+            "pixelUniqueContribution": 73,
+            "isBeingKept": true,
+            "roadId": 8567
+        },
+        {
+            "pixelSize": 139,
+            "pixelUniqueContribution": 126,
+            "isBeingKept": true,
+            "roadId": 9471
+        },
+        {
+            "pixelSize": 139,
+            "pixelUniqueContribution": 127,
+            "isBeingKept": true,
+            "roadId": 9731
+        },
+        {
+            "pixelSize": 139,
+            "pixelUniqueContribution": 115,
+            "isBeingKept": true,
+            "roadId": 10592
+        },
+        {
+            "pixelSize": 137,
+            "pixelUniqueContribution": 109,
+            "isBeingKept": true,
+            "roadId": 10227
+        },
+        {
+            "pixelSize": 136,
+            "pixelUniqueContribution": 136,
+            "isBeingKept": true,
+            "roadId": 8724
+        },
+        {
+            "pixelSize": 134,
+            "pixelUniqueContribution": 102,
+            "isBeingKept": true,
+            "roadId": 9227
+        },
+        {
+            "pixelSize": 131,
+            "pixelUniqueContribution": 122,
+            "isBeingKept": true,
+            "roadId": 9628
+        },
+        {
+            "pixelSize": 131,
+            "pixelUniqueContribution": 128,
+            "isBeingKept": true,
+            "roadId": 9414
+        },
+        {
+            "pixelSize": 131,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9736
+        },
+        {
+            "pixelSize": 130,
+            "pixelUniqueContribution": 93,
+            "isBeingKept": true,
+            "roadId": 23159
+        },
+        {
+            "pixelSize": 129,
+            "pixelUniqueContribution": 126,
+            "isBeingKept": true,
+            "roadId": 11168
+        },
+        {
+            "pixelSize": 129,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10287
+        },
+        {
+            "pixelSize": 129,
+            "pixelUniqueContribution": 43,
+            "isBeingKept": false,
+            "roadId": 8660
+        },
+        {
+            "pixelSize": 128,
+            "pixelUniqueContribution": 122,
+            "isBeingKept": true,
+            "roadId": 21308
+        },
+        {
+            "pixelSize": 128,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 21755
+        },
+        {
+            "pixelSize": 126,
+            "pixelUniqueContribution": 123,
+            "isBeingKept": true,
+            "roadId": 10111
+        },
+        {
+            "pixelSize": 126,
+            "pixelUniqueContribution": 126,
+            "isBeingKept": true,
+            "roadId": 20952
+        },
+        {
+            "pixelSize": 126,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11766
+        },
+        {
+            "pixelSize": 124,
+            "pixelUniqueContribution": 118,
+            "isBeingKept": true,
+            "roadId": 9674
+        },
+        {
+            "pixelSize": 123,
+            "pixelUniqueContribution": 123,
+            "isBeingKept": true,
+            "roadId": 9458
+        },
+        {
+            "pixelSize": 123,
+            "pixelUniqueContribution": 123,
+            "isBeingKept": true,
+            "roadId": 9260
+        },
+        {
+            "pixelSize": 120,
+            "pixelUniqueContribution": 102,
+            "isBeingKept": true,
+            "roadId": 10291
+        },
+        {
+            "pixelSize": 118,
+            "pixelUniqueContribution": 96,
+            "isBeingKept": true,
+            "roadId": 20892
+        },
+        {
+            "pixelSize": 118,
+            "pixelUniqueContribution": 115,
+            "isBeingKept": true,
+            "roadId": 11379
+        },
+        {
+            "pixelSize": 118,
+            "pixelUniqueContribution": 118,
+            "isBeingKept": true,
+            "roadId": 10245
+        },
+        {
+            "pixelSize": 117,
+            "pixelUniqueContribution": 94,
+            "isBeingKept": true,
+            "roadId": 21271
+        },
+        {
+            "pixelSize": 116,
+            "pixelUniqueContribution": 116,
+            "isBeingKept": true,
+            "roadId": 9462
+        },
+        {
+            "pixelSize": 116,
+            "pixelUniqueContribution": 106,
+            "isBeingKept": true,
+            "roadId": 8898
+        },
+        {
+            "pixelSize": 114,
+            "pixelUniqueContribution": 105,
+            "isBeingKept": true,
+            "roadId": 20896
+        },
+        {
+            "pixelSize": 113,
+            "pixelUniqueContribution": 103,
+            "isBeingKept": true,
+            "roadId": 9450
+        },
+        {
+            "pixelSize": 113,
+            "pixelUniqueContribution": 56,
+            "isBeingKept": false,
+            "roadId": 21084
+        },
+        {
+            "pixelSize": 113,
+            "pixelUniqueContribution": 73,
+            "isBeingKept": true,
+            "roadId": 8572
+        },
+        {
+            "pixelSize": 112,
+            "pixelUniqueContribution": 109,
+            "isBeingKept": true,
+            "roadId": 9397
+        },
+        {
+            "pixelSize": 112,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 7826
+        },
+        {
+            "pixelSize": 112,
+            "pixelUniqueContribution": 91,
+            "isBeingKept": true,
+            "roadId": 8528
+        },
+        {
+            "pixelSize": 111,
+            "pixelUniqueContribution": 109,
+            "isBeingKept": true,
+            "roadId": 9683
+        },
+        {
+            "pixelSize": 111,
+            "pixelUniqueContribution": 111,
+            "isBeingKept": true,
+            "roadId": 9012
+        },
+        {
+            "pixelSize": 109,
+            "pixelUniqueContribution": 106,
+            "isBeingKept": true,
+            "roadId": 8642
+        },
+        {
+            "pixelSize": 109,
+            "pixelUniqueContribution": 109,
+            "isBeingKept": true,
+            "roadId": 8803
+        },
+        {
+            "pixelSize": 109,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9561
+        },
+        {
+            "pixelSize": 104,
+            "pixelUniqueContribution": 51,
+            "isBeingKept": false,
+            "roadId": 9086
+        },
+        {
+            "pixelSize": 104,
+            "pixelUniqueContribution": 93,
+            "isBeingKept": true,
+            "roadId": 8812
+        },
+        {
+            "pixelSize": 103,
+            "pixelUniqueContribution": 97,
+            "isBeingKept": true,
+            "roadId": 9400
+        },
+        {
+            "pixelSize": 103,
+            "pixelUniqueContribution": 61,
+            "isBeingKept": true,
+            "roadId": 11691
+        },
+        {
+            "pixelSize": 102,
+            "pixelUniqueContribution": 102,
+            "isBeingKept": true,
+            "roadId": 9637
+        },
+        {
+            "pixelSize": 101,
+            "pixelUniqueContribution": 75,
+            "isBeingKept": true,
+            "roadId": 9166
+        },
+        {
+            "pixelSize": 101,
+            "pixelUniqueContribution": 94,
+            "isBeingKept": true,
+            "roadId": 9383
+        },
+        {
+            "pixelSize": 99,
+            "pixelUniqueContribution": 74,
+            "isBeingKept": true,
+            "roadId": 11831
+        },
+        {
+            "pixelSize": 99,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10859
+        },
+        {
+            "pixelSize": 98,
+            "pixelUniqueContribution": 50,
+            "isBeingKept": true,
+            "roadId": 9642
+        },
+        {
+            "pixelSize": 98,
+            "pixelUniqueContribution": 98,
+            "isBeingKept": true,
+            "roadId": 9413
+        },
+        {
+            "pixelSize": 98,
+            "pixelUniqueContribution": 88,
+            "isBeingKept": true,
+            "roadId": 10155
+        },
+        {
+            "pixelSize": 97,
+            "pixelUniqueContribution": 76,
+            "isBeingKept": true,
+            "roadId": 21482
+        },
+        {
+            "pixelSize": 97,
+            "pixelUniqueContribution": 64,
+            "isBeingKept": true,
+            "roadId": 8595
+        },
+        {
+            "pixelSize": 97,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8847
+        },
+        {
+            "pixelSize": 96,
+            "pixelUniqueContribution": 96,
+            "isBeingKept": true,
+            "roadId": 8843
+        },
+        {
+            "pixelSize": 96,
+            "pixelUniqueContribution": 96,
+            "isBeingKept": true,
+            "roadId": 9200
+        },
+        {
+            "pixelSize": 96,
+            "pixelUniqueContribution": 72,
+            "isBeingKept": true,
+            "roadId": 9176
+        },
+        {
+            "pixelSize": 96,
+            "pixelUniqueContribution": 94,
+            "isBeingKept": true,
+            "roadId": 9583
+        },
+        {
+            "pixelSize": 96,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9257
+        },
+        {
+            "pixelSize": 95,
+            "pixelUniqueContribution": 93,
+            "isBeingKept": true,
+            "roadId": 8897
+        },
+        {
+            "pixelSize": 95,
+            "pixelUniqueContribution": 87,
+            "isBeingKept": true,
+            "roadId": 21006
+        },
+        {
+            "pixelSize": 95,
+            "pixelUniqueContribution": 75,
+            "isBeingKept": true,
+            "roadId": 9725
+        },
+        {
+            "pixelSize": 94,
+            "pixelUniqueContribution": 79,
+            "isBeingKept": true,
+            "roadId": 9324
+        },
+        {
+            "pixelSize": 94,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": false,
+            "roadId": 10606
+        },
+        {
+            "pixelSize": 93,
+            "pixelUniqueContribution": 86,
+            "isBeingKept": true,
+            "roadId": 21342
+        },
+        {
+            "pixelSize": 93,
+            "pixelUniqueContribution": 46,
+            "isBeingKept": false,
+            "roadId": 9392
+        },
+        {
+            "pixelSize": 93,
+            "pixelUniqueContribution": 91,
+            "isBeingKept": true,
+            "roadId": 10329
+        },
+        {
+            "pixelSize": 92,
+            "pixelUniqueContribution": 50,
+            "isBeingKept": true,
+            "roadId": 9919
+        },
+        {
+            "pixelSize": 91,
+            "pixelUniqueContribution": 91,
+            "isBeingKept": true,
+            "roadId": 24682
+        },
+        {
+            "pixelSize": 91,
+            "pixelUniqueContribution": 81,
+            "isBeingKept": true,
+            "roadId": 8859
+        },
+        {
+            "pixelSize": 90,
+            "pixelUniqueContribution": 57,
+            "isBeingKept": true,
+            "roadId": 9638
+        },
+        {
+            "pixelSize": 89,
+            "pixelUniqueContribution": 86,
+            "isBeingKept": true,
+            "roadId": 20998
+        },
+        {
+            "pixelSize": 88,
+            "pixelUniqueContribution": 86,
+            "isBeingKept": true,
+            "roadId": 9014
+        },
+        {
+            "pixelSize": 88,
+            "pixelUniqueContribution": 82,
+            "isBeingKept": true,
+            "roadId": 8993
+        },
+        {
+            "pixelSize": 88,
+            "pixelUniqueContribution": 88,
+            "isBeingKept": true,
+            "roadId": 9379
+        },
+        {
+            "pixelSize": 87,
+            "pixelUniqueContribution": 68,
+            "isBeingKept": true,
+            "roadId": 8607
+        },
+        {
+            "pixelSize": 87,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 21464
+        },
+        {
+            "pixelSize": 86,
+            "pixelUniqueContribution": 73,
+            "isBeingKept": true,
+            "roadId": 9525
+        },
+        {
+            "pixelSize": 86,
+            "pixelUniqueContribution": 86,
+            "isBeingKept": true,
+            "roadId": 8875
+        },
+        {
+            "pixelSize": 85,
+            "pixelUniqueContribution": 83,
+            "isBeingKept": true,
+            "roadId": 9895
+        },
+        {
+            "pixelSize": 84,
+            "pixelUniqueContribution": 68,
+            "isBeingKept": true,
+            "roadId": 21696
+        },
+        {
+            "pixelSize": 84,
+            "pixelUniqueContribution": 76,
+            "isBeingKept": true,
+            "roadId": 9684
+        },
+        {
+            "pixelSize": 84,
+            "pixelUniqueContribution": 77,
+            "isBeingKept": true,
+            "roadId": 9832
+        },
+        {
+            "pixelSize": 83,
+            "pixelUniqueContribution": 70,
+            "isBeingKept": true,
+            "roadId": 10362
+        },
+        {
+            "pixelSize": 82,
+            "pixelUniqueContribution": 55,
+            "isBeingKept": true,
+            "roadId": 22830
+        },
+        {
+            "pixelSize": 82,
+            "pixelUniqueContribution": 74,
+            "isBeingKept": true,
+            "roadId": 8571
+        },
+        {
+            "pixelSize": 81,
+            "pixelUniqueContribution": 73,
+            "isBeingKept": true,
+            "roadId": 9749
+        },
+        {
+            "pixelSize": 81,
+            "pixelUniqueContribution": 26,
+            "isBeingKept": false,
+            "roadId": 8915
+        },
+        {
+            "pixelSize": 81,
+            "pixelUniqueContribution": 59,
+            "isBeingKept": true,
+            "roadId": 8871
+        },
+        {
+            "pixelSize": 81,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9490
+        },
+        {
+            "pixelSize": 80,
+            "pixelUniqueContribution": 72,
+            "isBeingKept": true,
+            "roadId": 11174
+        },
+        {
+            "pixelSize": 79,
+            "pixelUniqueContribution": 56,
+            "isBeingKept": true,
+            "roadId": 21264
+        },
+        {
+            "pixelSize": 79,
+            "pixelUniqueContribution": 73,
+            "isBeingKept": true,
+            "roadId": 8623
+        },
+        {
+            "pixelSize": 79,
+            "pixelUniqueContribution": 67,
+            "isBeingKept": true,
+            "roadId": 9504
+        },
+        {
+            "pixelSize": 79,
+            "pixelUniqueContribution": 48,
+            "isBeingKept": true,
+            "roadId": 21339
+        },
+        {
+            "pixelSize": 78,
+            "pixelUniqueContribution": 78,
+            "isBeingKept": true,
+            "roadId": 9158
+        },
+        {
+            "pixelSize": 78,
+            "pixelUniqueContribution": 78,
+            "isBeingKept": true,
+            "roadId": 9707
+        },
+        {
+            "pixelSize": 78,
+            "pixelUniqueContribution": 61,
+            "isBeingKept": true,
+            "roadId": 9566
+        },
+        {
+            "pixelSize": 77,
+            "pixelUniqueContribution": 67,
+            "isBeingKept": true,
+            "roadId": 8962
+        },
+        {
+            "pixelSize": 77,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8836
+        },
+        {
+            "pixelSize": 76,
+            "pixelUniqueContribution": 70,
+            "isBeingKept": true,
+            "roadId": 24675
+        },
+        {
+            "pixelSize": 75,
+            "pixelUniqueContribution": 65,
+            "isBeingKept": true,
+            "roadId": 11822
+        },
+        {
+            "pixelSize": 75,
+            "pixelUniqueContribution": 66,
+            "isBeingKept": true,
+            "roadId": 11519
+        },
+        {
+            "pixelSize": 75,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9869
+        },
+        {
+            "pixelSize": 75,
+            "pixelUniqueContribution": 44,
+            "isBeingKept": true,
+            "roadId": 10436
+        },
+        {
+            "pixelSize": 75,
+            "pixelUniqueContribution": 54,
+            "isBeingKept": true,
+            "roadId": 9182
+        },
+        {
+            "pixelSize": 75,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8846
+        },
+        {
+            "pixelSize": 72,
+            "pixelUniqueContribution": 33,
+            "isBeingKept": false,
+            "roadId": 8716
+        },
+        {
+            "pixelSize": 72,
+            "pixelUniqueContribution": 72,
+            "isBeingKept": true,
+            "roadId": 21382
+        },
+        {
+            "pixelSize": 70,
+            "pixelUniqueContribution": 51,
+            "isBeingKept": true,
+            "roadId": 21044
+        },
+        {
+            "pixelSize": 70,
+            "pixelUniqueContribution": 65,
+            "isBeingKept": true,
+            "roadId": 10184
+        },
+        {
+            "pixelSize": 70,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11035
+        },
+        {
+            "pixelSize": 69,
+            "pixelUniqueContribution": 46,
+            "isBeingKept": true,
+            "roadId": 9288
+        },
+        {
+            "pixelSize": 68,
+            "pixelUniqueContribution": 50,
+            "isBeingKept": true,
+            "roadId": 9388
+        },
+        {
+            "pixelSize": 67,
+            "pixelUniqueContribution": 22,
+            "isBeingKept": false,
+            "roadId": 9109
+        },
+        {
+            "pixelSize": 67,
+            "pixelUniqueContribution": 62,
+            "isBeingKept": true,
+            "roadId": 9057
+        },
+        {
+            "pixelSize": 65,
+            "pixelUniqueContribution": 45,
+            "isBeingKept": true,
+            "roadId": 21517
+        },
+        {
+            "pixelSize": 65,
+            "pixelUniqueContribution": 57,
+            "isBeingKept": true,
+            "roadId": 9327
+        },
+        {
+            "pixelSize": 65,
+            "pixelUniqueContribution": 52,
+            "isBeingKept": true,
+            "roadId": 8544
+        },
+        {
+            "pixelSize": 65,
+            "pixelUniqueContribution": 62,
+            "isBeingKept": true,
+            "roadId": 11479
+        },
+        {
+            "pixelSize": 65,
+            "pixelUniqueContribution": 43,
+            "isBeingKept": true,
+            "roadId": 9443
+        },
+        {
+            "pixelSize": 65,
+            "pixelUniqueContribution": 50,
+            "isBeingKept": true,
+            "roadId": 8666
+        },
+        {
+            "pixelSize": 64,
+            "pixelUniqueContribution": 58,
+            "isBeingKept": true,
+            "roadId": 8730
+        },
+        {
+            "pixelSize": 64,
+            "pixelUniqueContribution": 29,
+            "isBeingKept": false,
+            "roadId": 8680
+        },
+        {
+            "pixelSize": 64,
+            "pixelUniqueContribution": 64,
+            "isBeingKept": true,
+            "roadId": 9693
+        },
+        {
+            "pixelSize": 63,
+            "pixelUniqueContribution": 63,
+            "isBeingKept": true,
+            "roadId": 9354
+        },
+        {
+            "pixelSize": 62,
+            "pixelUniqueContribution": 36,
+            "isBeingKept": true,
+            "roadId": 9138
+        },
+        {
+            "pixelSize": 62,
+            "pixelUniqueContribution": 57,
+            "isBeingKept": true,
+            "roadId": 21030
+        },
+        {
+            "pixelSize": 62,
+            "pixelUniqueContribution": 22,
+            "isBeingKept": false,
+            "roadId": 11111
+        },
+        {
+            "pixelSize": 62,
+            "pixelUniqueContribution": 62,
+            "isBeingKept": true,
+            "roadId": 11819
+        },
+        {
+            "pixelSize": 61,
+            "pixelUniqueContribution": 45,
+            "isBeingKept": true,
+            "roadId": 20888
+        },
+        {
+            "pixelSize": 61,
+            "pixelUniqueContribution": 45,
+            "isBeingKept": true,
+            "roadId": 21412
+        },
+        {
+            "pixelSize": 61,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": false,
+            "roadId": 9569
+        },
+        {
+            "pixelSize": 61,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": false,
+            "roadId": 8706
+        },
+        {
+            "pixelSize": 60,
+            "pixelUniqueContribution": 60,
+            "isBeingKept": true,
+            "roadId": 9367
+        },
+        {
+            "pixelSize": 60,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8640
+        },
+        {
+            "pixelSize": 60,
+            "pixelUniqueContribution": 29,
+            "isBeingKept": false,
+            "roadId": 8758
+        },
+        {
+            "pixelSize": 59,
+            "pixelUniqueContribution": 28,
+            "isBeingKept": false,
+            "roadId": 21578
+        },
+        {
+            "pixelSize": 59,
+            "pixelUniqueContribution": 47,
+            "isBeingKept": true,
+            "roadId": 8912
+        },
+        {
+            "pixelSize": 59,
+            "pixelUniqueContribution": 54,
+            "isBeingKept": true,
+            "roadId": 11360
+        },
+        {
+            "pixelSize": 59,
+            "pixelUniqueContribution": 34,
+            "isBeingKept": true,
+            "roadId": 9351
+        },
+        {
+            "pixelSize": 59,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11667
+        },
+        {
+            "pixelSize": 58,
+            "pixelUniqueContribution": 43,
+            "isBeingKept": true,
+            "roadId": 9129
+        },
+        {
+            "pixelSize": 58,
+            "pixelUniqueContribution": 58,
+            "isBeingKept": true,
+            "roadId": 9218
+        },
+        {
+            "pixelSize": 57,
+            "pixelUniqueContribution": 50,
+            "isBeingKept": true,
+            "roadId": 8573
+        },
+        {
+            "pixelSize": 57,
+            "pixelUniqueContribution": 50,
+            "isBeingKept": true,
+            "roadId": 10723
+        },
+        {
+            "pixelSize": 57,
+            "pixelUniqueContribution": 57,
+            "isBeingKept": true,
+            "roadId": 21421
+        },
+        {
+            "pixelSize": 57,
+            "pixelUniqueContribution": 9,
+            "isBeingKept": false,
+            "roadId": 21171
+        },
+        {
+            "pixelSize": 56,
+            "pixelUniqueContribution": 19,
+            "isBeingKept": false,
+            "roadId": 8781
+        },
+        {
+            "pixelSize": 55,
+            "pixelUniqueContribution": 38,
+            "isBeingKept": true,
+            "roadId": 9480
+        },
+        {
+            "pixelSize": 55,
+            "pixelUniqueContribution": 49,
+            "isBeingKept": true,
+            "roadId": 21330
+        },
+        {
+            "pixelSize": 55,
+            "pixelUniqueContribution": 44,
+            "isBeingKept": true,
+            "roadId": 22202
+        },
+        {
+            "pixelSize": 54,
+            "pixelUniqueContribution": 46,
+            "isBeingKept": true,
+            "roadId": 8736
+        },
+        {
+            "pixelSize": 54,
+            "pixelUniqueContribution": 14,
+            "isBeingKept": false,
+            "roadId": 21513
+        },
+        {
+            "pixelSize": 54,
+            "pixelUniqueContribution": 43,
+            "isBeingKept": true,
+            "roadId": 8868
+        },
+        {
+            "pixelSize": 53,
+            "pixelUniqueContribution": 41,
+            "isBeingKept": true,
+            "roadId": 19953
+        },
+        {
+            "pixelSize": 53,
+            "pixelUniqueContribution": 46,
+            "isBeingKept": true,
+            "roadId": 9551
+        },
+        {
+            "pixelSize": 53,
+            "pixelUniqueContribution": 53,
+            "isBeingKept": true,
+            "roadId": 9398
+        },
+        {
+            "pixelSize": 52,
+            "pixelUniqueContribution": 36,
+            "isBeingKept": true,
+            "roadId": 11506
+        },
+        {
+            "pixelSize": 51,
+            "pixelUniqueContribution": 43,
+            "isBeingKept": true,
+            "roadId": 10816
+        },
+        {
+            "pixelSize": 51,
+            "pixelUniqueContribution": 42,
+            "isBeingKept": true,
+            "roadId": 8601
+        },
+        {
+            "pixelSize": 51,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8949
+        },
+        {
+            "pixelSize": 51,
+            "pixelUniqueContribution": 16,
+            "isBeingKept": false,
+            "roadId": 8852
+        },
+        {
+            "pixelSize": 51,
+            "pixelUniqueContribution": 9,
+            "isBeingKept": false,
+            "roadId": 21727
+        },
+        {
+            "pixelSize": 51,
+            "pixelUniqueContribution": 51,
+            "isBeingKept": true,
+            "roadId": 24809
+        },
+        {
+            "pixelSize": 51,
+            "pixelUniqueContribution": 35,
+            "isBeingKept": true,
+            "roadId": 21031
+        },
+        {
+            "pixelSize": 50,
+            "pixelUniqueContribution": 29,
+            "isBeingKept": true,
+            "roadId": 9103
+        },
+        {
+            "pixelSize": 50,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 9412
+        },
+        {
+            "pixelSize": 50,
+            "pixelUniqueContribution": 40,
+            "isBeingKept": true,
+            "roadId": 21688
+        },
+        {
+            "pixelSize": 50,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": false,
+            "roadId": 9539
+        },
+        {
+            "pixelSize": 50,
+            "pixelUniqueContribution": 38,
+            "isBeingKept": true,
+            "roadId": 20920
+        },
+        {
+            "pixelSize": 50,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 8882
+        },
+        {
+            "pixelSize": 49,
+            "pixelUniqueContribution": 37,
+            "isBeingKept": true,
+            "roadId": 9582
+        },
+        {
+            "pixelSize": 49,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8867
+        },
+        {
+            "pixelSize": 49,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": true,
+            "roadId": 9625
+        },
+        {
+            "pixelSize": 49,
+            "pixelUniqueContribution": 42,
+            "isBeingKept": true,
+            "roadId": 9717
+        },
+        {
+            "pixelSize": 49,
+            "pixelUniqueContribution": 32,
+            "isBeingKept": true,
+            "roadId": 9622
+        },
+        {
+            "pixelSize": 48,
+            "pixelUniqueContribution": 18,
+            "isBeingKept": false,
+            "roadId": 8596
+        },
+        {
+            "pixelSize": 48,
+            "pixelUniqueContribution": 44,
+            "isBeingKept": true,
+            "roadId": 21485
+        },
+        {
+            "pixelSize": 48,
+            "pixelUniqueContribution": 27,
+            "isBeingKept": true,
+            "roadId": 9270
+        },
+        {
+            "pixelSize": 47,
+            "pixelUniqueContribution": 24,
+            "isBeingKept": true,
+            "roadId": 9039
+        },
+        {
+            "pixelSize": 47,
+            "pixelUniqueContribution": 32,
+            "isBeingKept": true,
+            "roadId": 9181
+        },
+        {
+            "pixelSize": 47,
+            "pixelUniqueContribution": 16,
+            "isBeingKept": false,
+            "roadId": 9207
+        },
+        {
+            "pixelSize": 47,
+            "pixelUniqueContribution": 11,
+            "isBeingKept": false,
+            "roadId": 11511
+        },
+        {
+            "pixelSize": 47,
+            "pixelUniqueContribution": 33,
+            "isBeingKept": true,
+            "roadId": 8696
+        },
+        {
+            "pixelSize": 46,
+            "pixelUniqueContribution": 38,
+            "isBeingKept": true,
+            "roadId": 8692
+        },
+        {
+            "pixelSize": 46,
+            "pixelUniqueContribution": 32,
+            "isBeingKept": true,
+            "roadId": 10152
+        },
+        {
+            "pixelSize": 46,
+            "pixelUniqueContribution": 29,
+            "isBeingKept": true,
+            "roadId": 9210
+        },
+        {
+            "pixelSize": 46,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11221
+        },
+        {
+            "pixelSize": 45,
+            "pixelUniqueContribution": 43,
+            "isBeingKept": true,
+            "roadId": 20910
+        },
+        {
+            "pixelSize": 45,
+            "pixelUniqueContribution": 43,
+            "isBeingKept": true,
+            "roadId": 9669
+        },
+        {
+            "pixelSize": 45,
+            "pixelUniqueContribution": 45,
+            "isBeingKept": true,
+            "roadId": 9113
+        },
+        {
+            "pixelSize": 45,
+            "pixelUniqueContribution": 34,
+            "isBeingKept": true,
+            "roadId": 21130
+        },
+        {
+            "pixelSize": 45,
+            "pixelUniqueContribution": 33,
+            "isBeingKept": true,
+            "roadId": 11752
+        },
+        {
+            "pixelSize": 44,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": true,
+            "roadId": 8603
+        },
+        {
+            "pixelSize": 44,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": true,
+            "roadId": 10205
+        },
+        {
+            "pixelSize": 44,
+            "pixelUniqueContribution": 36,
+            "isBeingKept": true,
+            "roadId": 8959
+        },
+        {
+            "pixelSize": 44,
+            "pixelUniqueContribution": 37,
+            "isBeingKept": true,
+            "roadId": 9826
+        },
+        {
+            "pixelSize": 44,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": true,
+            "roadId": 18915
+        },
+        {
+            "pixelSize": 44,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10128
+        },
+        {
+            "pixelSize": 44,
+            "pixelUniqueContribution": 26,
+            "isBeingKept": true,
+            "roadId": 21278
+        },
+        {
+            "pixelSize": 43,
+            "pixelUniqueContribution": 31,
+            "isBeingKept": true,
+            "roadId": 8563
+        },
+        {
+            "pixelSize": 42,
+            "pixelUniqueContribution": 23,
+            "isBeingKept": true,
+            "roadId": 9497
+        },
+        {
+            "pixelSize": 42,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 9585
+        },
+        {
+            "pixelSize": 42,
+            "pixelUniqueContribution": 24,
+            "isBeingKept": true,
+            "roadId": 9307
+        },
+        {
+            "pixelSize": 42,
+            "pixelUniqueContribution": 28,
+            "isBeingKept": true,
+            "roadId": 9601
+        },
+        {
+            "pixelSize": 42,
+            "pixelUniqueContribution": 38,
+            "isBeingKept": true,
+            "roadId": 9724
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 31,
+            "isBeingKept": true,
+            "roadId": 9536
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 19,
+            "isBeingKept": false,
+            "roadId": 21709
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 30,
+            "isBeingKept": true,
+            "roadId": 19489
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 27,
+            "isBeingKept": true,
+            "roadId": 9203
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 21,
+            "isBeingKept": true,
+            "roadId": 21702
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 14,
+            "isBeingKept": false,
+            "roadId": 9060
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 9,
+            "isBeingKept": false,
+            "roadId": 10412
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 4,
+            "isBeingKept": false,
+            "roadId": 9972
+        },
+        {
+            "pixelSize": 41,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": true,
+            "roadId": 9557
+        },
+        {
+            "pixelSize": 40,
+            "pixelUniqueContribution": 26,
+            "isBeingKept": true,
+            "roadId": 9003
+        },
+        {
+            "pixelSize": 38,
+            "pixelUniqueContribution": 30,
+            "isBeingKept": true,
+            "roadId": 11072
+        },
+        {
+            "pixelSize": 38,
+            "pixelUniqueContribution": 20,
+            "isBeingKept": true,
+            "roadId": 8848
+        },
+        {
+            "pixelSize": 38,
+            "pixelUniqueContribution": 20,
+            "isBeingKept": true,
+            "roadId": 21676
+        },
+        {
+            "pixelSize": 38,
+            "pixelUniqueContribution": 17,
+            "isBeingKept": false,
+            "roadId": 8712
+        },
+        {
+            "pixelSize": 37,
+            "pixelUniqueContribution": 26,
+            "isBeingKept": true,
+            "roadId": 9788
+        },
+        {
+            "pixelSize": 37,
+            "pixelUniqueContribution": 20,
+            "isBeingKept": true,
+            "roadId": 8973
+        },
+        {
+            "pixelSize": 37,
+            "pixelUniqueContribution": 16,
+            "isBeingKept": false,
+            "roadId": 11666
+        },
+        {
+            "pixelSize": 37,
+            "pixelUniqueContribution": 23,
+            "isBeingKept": true,
+            "roadId": 9299
+        },
+        {
+            "pixelSize": 37,
+            "pixelUniqueContribution": 26,
+            "isBeingKept": true,
+            "roadId": 21589
+        },
+        {
+            "pixelSize": 36,
+            "pixelUniqueContribution": 24,
+            "isBeingKept": true,
+            "roadId": 8796
+        },
+        {
+            "pixelSize": 36,
+            "pixelUniqueContribution": 32,
+            "isBeingKept": true,
+            "roadId": 8501
+        },
+        {
+            "pixelSize": 36,
+            "pixelUniqueContribution": 29,
+            "isBeingKept": true,
+            "roadId": 10600
+        },
+        {
+            "pixelSize": 36,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 20978
+        },
+        {
+            "pixelSize": 35,
+            "pixelUniqueContribution": 7,
+            "isBeingKept": false,
+            "roadId": 9623
+        },
+        {
+            "pixelSize": 35,
+            "pixelUniqueContribution": 16,
+            "isBeingKept": false,
+            "roadId": 21253
+        },
+        {
+            "pixelSize": 34,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9107
+        },
+        {
+            "pixelSize": 34,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": true,
+            "roadId": 9468
+        },
+        {
+            "pixelSize": 33,
+            "pixelUniqueContribution": 20,
+            "isBeingKept": true,
+            "roadId": 9723
+        },
+        {
+            "pixelSize": 33,
+            "pixelUniqueContribution": 30,
+            "isBeingKept": true,
+            "roadId": 9197
+        },
+        {
+            "pixelSize": 33,
+            "pixelUniqueContribution": 17,
+            "isBeingKept": true,
+            "roadId": 8824
+        },
+        {
+            "pixelSize": 33,
+            "pixelUniqueContribution": 16,
+            "isBeingKept": false,
+            "roadId": 9659
+        },
+        {
+            "pixelSize": 33,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 21334
+        },
+        {
+            "pixelSize": 32,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 9662
+        },
+        {
+            "pixelSize": 32,
+            "pixelUniqueContribution": 24,
+            "isBeingKept": true,
+            "roadId": 19640
+        },
+        {
+            "pixelSize": 32,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 8705
+        },
+        {
+            "pixelSize": 32,
+            "pixelUniqueContribution": 8,
+            "isBeingKept": false,
+            "roadId": 8559
+        },
+        {
+            "pixelSize": 31,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": true,
+            "roadId": 8908
+        },
+        {
+            "pixelSize": 31,
+            "pixelUniqueContribution": 31,
+            "isBeingKept": true,
+            "roadId": 10048
+        },
+        {
+            "pixelSize": 31,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10019
+        },
+        {
+            "pixelSize": 30,
+            "pixelUniqueContribution": 28,
+            "isBeingKept": true,
+            "roadId": 8546
+        },
+        {
+            "pixelSize": 30,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 9753
+        },
+        {
+            "pixelSize": 30,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 8970
+        },
+        {
+            "pixelSize": 30,
+            "pixelUniqueContribution": 18,
+            "isBeingKept": true,
+            "roadId": 9165
+        },
+        {
+            "pixelSize": 30,
+            "pixelUniqueContribution": 30,
+            "isBeingKept": true,
+            "roadId": 21683
+        },
+        {
+            "pixelSize": 30,
+            "pixelUniqueContribution": 24,
+            "isBeingKept": true,
+            "roadId": 10007
+        },
+        {
+            "pixelSize": 30,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 17892
+        },
+        {
+            "pixelSize": 30,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8506
+        },
+        {
+            "pixelSize": 29,
+            "pixelUniqueContribution": 25,
+            "isBeingKept": true,
+            "roadId": 9572
+        },
+        {
+            "pixelSize": 29,
+            "pixelUniqueContribution": 17,
+            "isBeingKept": true,
+            "roadId": 20960
+        },
+        {
+            "pixelSize": 29,
+            "pixelUniqueContribution": 16,
+            "isBeingKept": true,
+            "roadId": 9017
+        },
+        {
+            "pixelSize": 29,
+            "pixelUniqueContribution": 12,
+            "isBeingKept": false,
+            "roadId": 8982
+        },
+        {
+            "pixelSize": 29,
+            "pixelUniqueContribution": 20,
+            "isBeingKept": true,
+            "roadId": 8992
+        },
+        {
+            "pixelSize": 28,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": false,
+            "roadId": 8668
+        },
+        {
+            "pixelSize": 28,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 8935
+        },
+        {
+            "pixelSize": 28,
+            "pixelUniqueContribution": 20,
+            "isBeingKept": true,
+            "roadId": 9508
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 24,
+            "isBeingKept": true,
+            "roadId": 9587
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8905
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 11,
+            "isBeingKept": false,
+            "roadId": 9061
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 17,
+            "isBeingKept": true,
+            "roadId": 21110
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 19,
+            "isBeingKept": true,
+            "roadId": 21142
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 19,
+            "isBeingKept": true,
+            "roadId": 9703
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": false,
+            "roadId": 8931
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 11711
+        },
+        {
+            "pixelSize": 27,
+            "pixelUniqueContribution": 12,
+            "isBeingKept": false,
+            "roadId": 9478
+        },
+        {
+            "pixelSize": 26,
+            "pixelUniqueContribution": 14,
+            "isBeingKept": true,
+            "roadId": 8895
+        },
+        {
+            "pixelSize": 26,
+            "pixelUniqueContribution": 21,
+            "isBeingKept": true,
+            "roadId": 9358
+        },
+        {
+            "pixelSize": 26,
+            "pixelUniqueContribution": 8,
+            "isBeingKept": false,
+            "roadId": 9522
+        },
+        {
+            "pixelSize": 26,
+            "pixelUniqueContribution": 18,
+            "isBeingKept": true,
+            "roadId": 8686
+        },
+        {
+            "pixelSize": 25,
+            "pixelUniqueContribution": 15,
+            "isBeingKept": true,
+            "roadId": 9424
+        },
+        {
+            "pixelSize": 25,
+            "pixelUniqueContribution": 18,
+            "isBeingKept": true,
+            "roadId": 9599
+        },
+        {
+            "pixelSize": 25,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 11788
+        },
+        {
+            "pixelSize": 25,
+            "pixelUniqueContribution": 14,
+            "isBeingKept": true,
+            "roadId": 8535
+        },
+        {
+            "pixelSize": 25,
+            "pixelUniqueContribution": 8,
+            "isBeingKept": false,
+            "roadId": 20943
+        },
+        {
+            "pixelSize": 25,
+            "pixelUniqueContribution": 20,
+            "isBeingKept": true,
+            "roadId": 8661
+        },
+        {
+            "pixelSize": 25,
+            "pixelUniqueContribution": 11,
+            "isBeingKept": false,
+            "roadId": 21148
+        },
+        {
+            "pixelSize": 24,
+            "pixelUniqueContribution": 14,
+            "isBeingKept": true,
+            "roadId": 10805
+        },
+        {
+            "pixelSize": 24,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 21236
+        },
+        {
+            "pixelSize": 24,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 9079
+        },
+        {
+            "pixelSize": 24,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 9546
+        },
+        {
+            "pixelSize": 24,
+            "pixelUniqueContribution": 15,
+            "isBeingKept": true,
+            "roadId": 8533
+        },
+        {
+            "pixelSize": 23,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 20904
+        },
+        {
+            "pixelSize": 23,
+            "pixelUniqueContribution": 7,
+            "isBeingKept": false,
+            "roadId": 23318
+        },
+        {
+            "pixelSize": 23,
+            "pixelUniqueContribution": 15,
+            "isBeingKept": true,
+            "roadId": 9267
+        },
+        {
+            "pixelSize": 23,
+            "pixelUniqueContribution": 17,
+            "isBeingKept": true,
+            "roadId": 8929
+        },
+        {
+            "pixelSize": 23,
+            "pixelUniqueContribution": 17,
+            "isBeingKept": true,
+            "roadId": 21062
+        },
+        {
+            "pixelSize": 23,
+            "pixelUniqueContribution": 17,
+            "isBeingKept": true,
+            "roadId": 21604
+        },
+        {
+            "pixelSize": 23,
+            "pixelUniqueContribution": 14,
+            "isBeingKept": true,
+            "roadId": 9660
+        },
+        {
+            "pixelSize": 23,
+            "pixelUniqueContribution": 14,
+            "isBeingKept": true,
+            "roadId": 9144
+        },
+        {
+            "pixelSize": 22,
+            "pixelUniqueContribution": 5,
+            "isBeingKept": false,
+            "roadId": 21619
+        },
+        {
+            "pixelSize": 22,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": false,
+            "roadId": 21427
+        },
+        {
+            "pixelSize": 22,
+            "pixelUniqueContribution": 8,
+            "isBeingKept": false,
+            "roadId": 9241
+        },
+        {
+            "pixelSize": 22,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": true,
+            "roadId": 11130
+        },
+        {
+            "pixelSize": 21,
+            "pixelUniqueContribution": 16,
+            "isBeingKept": true,
+            "roadId": 9781
+        },
+        {
+            "pixelSize": 21,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": false,
+            "roadId": 11565
+        },
+        {
+            "pixelSize": 21,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8698
+        },
+        {
+            "pixelSize": 21,
+            "pixelUniqueContribution": 12,
+            "isBeingKept": true,
+            "roadId": 9131
+        },
+        {
+            "pixelSize": 21,
+            "pixelUniqueContribution": 17,
+            "isBeingKept": true,
+            "roadId": 8966
+        },
+        {
+            "pixelSize": 21,
+            "pixelUniqueContribution": 15,
+            "isBeingKept": true,
+            "roadId": 9239
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 9,
+            "isBeingKept": false,
+            "roadId": 8919
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 9,
+            "isBeingKept": false,
+            "roadId": 9668
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 11,
+            "isBeingKept": true,
+            "roadId": 9029
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 9721
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 12,
+            "isBeingKept": true,
+            "roadId": 11444
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 16,
+            "isBeingKept": true,
+            "roadId": 9554
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 5,
+            "isBeingKept": false,
+            "roadId": 9245
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 12,
+            "isBeingKept": true,
+            "roadId": 9475
+        },
+        {
+            "pixelSize": 20,
+            "pixelUniqueContribution": 9,
+            "isBeingKept": false,
+            "roadId": 9442
+        },
+        {
+            "pixelSize": 19,
+            "pixelUniqueContribution": 8,
+            "isBeingKept": false,
+            "roadId": 9262
+        },
+        {
+            "pixelSize": 19,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": true,
+            "roadId": 18534
+        },
+        {
+            "pixelSize": 19,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 18406
+        },
+        {
+            "pixelSize": 19,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 9559
+        },
+        {
+            "pixelSize": 19,
+            "pixelUniqueContribution": 5,
+            "isBeingKept": false,
+            "roadId": 21219
+        },
+        {
+            "pixelSize": 18,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": true,
+            "roadId": 21205
+        },
+        {
+            "pixelSize": 18,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": true,
+            "roadId": 20985
+        },
+        {
+            "pixelSize": 18,
+            "pixelUniqueContribution": 11,
+            "isBeingKept": true,
+            "roadId": 20933
+        },
+        {
+            "pixelSize": 18,
+            "pixelUniqueContribution": 7,
+            "isBeingKept": false,
+            "roadId": 8507
+        },
+        {
+            "pixelSize": 18,
+            "pixelUniqueContribution": 11,
+            "isBeingKept": true,
+            "roadId": 8986
+        },
+        {
+            "pixelSize": 18,
+            "pixelUniqueContribution": 15,
+            "isBeingKept": true,
+            "roadId": 11214
+        },
+        {
+            "pixelSize": 18,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10574
+        },
+        {
+            "pixelSize": 18,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": true,
+            "roadId": 8953
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 12,
+            "isBeingKept": true,
+            "roadId": 10406
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 7,
+            "isBeingKept": false,
+            "roadId": 9756
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": true,
+            "roadId": 8788
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 21010
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 11,
+            "isBeingKept": true,
+            "roadId": 8495
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10062
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 15,
+            "isBeingKept": true,
+            "roadId": 9560
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 20908
+        },
+        {
+            "pixelSize": 17,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": true,
+            "roadId": 22943
+        },
+        {
+            "pixelSize": 16,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 9766
+        },
+        {
+            "pixelSize": 16,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 21309
+        },
+        {
+            "pixelSize": 16,
+            "pixelUniqueContribution": 10,
+            "isBeingKept": true,
+            "roadId": 9420
+        },
+        {
+            "pixelSize": 16,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11654
+        },
+        {
+            "pixelSize": 16,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 20735
+        },
+        {
+            "pixelSize": 16,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 9317
+        },
+        {
+            "pixelSize": 16,
+            "pixelUniqueContribution": 14,
+            "isBeingKept": true,
+            "roadId": 11473
+        },
+        {
+            "pixelSize": 15,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 9278
+        },
+        {
+            "pixelSize": 15,
+            "pixelUniqueContribution": 9,
+            "isBeingKept": true,
+            "roadId": 11740
+        },
+        {
+            "pixelSize": 15,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 24840
+        },
+        {
+            "pixelSize": 15,
+            "pixelUniqueContribution": 3,
+            "isBeingKept": false,
+            "roadId": 8985
+        },
+        {
+            "pixelSize": 15,
+            "pixelUniqueContribution": 8,
+            "isBeingKept": true,
+            "roadId": 20999
+        },
+        {
+            "pixelSize": 15,
+            "pixelUniqueContribution": 3,
+            "isBeingKept": false,
+            "roadId": 8561
+        },
+        {
+            "pixelSize": 14,
+            "pixelUniqueContribution": 8,
+            "isBeingKept": true,
+            "roadId": 9193
+        },
+        {
+            "pixelSize": 14,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 21666
+        },
+        {
+            "pixelSize": 14,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 8877
+        },
+        {
+            "pixelSize": 14,
+            "pixelUniqueContribution": 13,
+            "isBeingKept": true,
+            "roadId": 22927
+        },
+        {
+            "pixelSize": 13,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": false,
+            "roadId": 8516
+        },
+        {
+            "pixelSize": 13,
+            "pixelUniqueContribution": 7,
+            "isBeingKept": true,
+            "roadId": 18143
+        },
+        {
+            "pixelSize": 13,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11503
+        },
+        {
+            "pixelSize": 13,
+            "pixelUniqueContribution": 7,
+            "isBeingKept": true,
+            "roadId": 9378
+        },
+        {
+            "pixelSize": 13,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 11581
+        },
+        {
+            "pixelSize": 12,
+            "pixelUniqueContribution": 8,
+            "isBeingKept": true,
+            "roadId": 10073
+        },
+        {
+            "pixelSize": 12,
+            "pixelUniqueContribution": 3,
+            "isBeingKept": false,
+            "roadId": 21803
+        },
+        {
+            "pixelSize": 12,
+            "pixelUniqueContribution": 3,
+            "isBeingKept": false,
+            "roadId": 22351
+        },
+        {
+            "pixelSize": 12,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 7356
+        },
+        {
+            "pixelSize": 12,
+            "pixelUniqueContribution": 3,
+            "isBeingKept": false,
+            "roadId": 22549
+        },
+        {
+            "pixelSize": 12,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 8866
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 10537
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9052
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 21163
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": true,
+            "roadId": 10210
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 8749
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 5,
+            "isBeingKept": false,
+            "roadId": 10939
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 20976
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 9295
+        },
+        {
+            "pixelSize": 11,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": true,
+            "roadId": 10279
+        },
+        {
+            "pixelSize": 10,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 22460
+        },
+        {
+            "pixelSize": 10,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 9460
+        },
+        {
+            "pixelSize": 10,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9923
+        },
+        {
+            "pixelSize": 10,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 21813
+        },
+        {
+            "pixelSize": 10,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9350
+        },
+        {
+            "pixelSize": 10,
+            "pixelUniqueContribution": 4,
+            "isBeingKept": false,
+            "roadId": 23062
+        },
+        {
+            "pixelSize": 10,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9415
+        },
+        {
+            "pixelSize": 10,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": true,
+            "roadId": 11243
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 10232
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 5,
+            "isBeingKept": true,
+            "roadId": 11160
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22676
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9691
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22174
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 10381
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 11143
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9453
+        },
+        {
+            "pixelSize": 9,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22735
+        },
+        {
+            "pixelSize": 8,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 21736
+        },
+        {
+            "pixelSize": 8,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11003
+        },
+        {
+            "pixelSize": 8,
+            "pixelUniqueContribution": 2,
+            "isBeingKept": false,
+            "roadId": 21524
+        },
+        {
+            "pixelSize": 8,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9225
+        },
+        {
+            "pixelSize": 8,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8998
+        },
+        {
+            "pixelSize": 8,
+            "pixelUniqueContribution": 4,
+            "isBeingKept": false,
+            "roadId": 18789
+        },
+        {
+            "pixelSize": 8,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10033
+        },
+        {
+            "pixelSize": 8,
+            "pixelUniqueContribution": 4,
+            "isBeingKept": false,
+            "roadId": 9540
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9646
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10835
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22007
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 20974
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 6,
+            "isBeingKept": true,
+            "roadId": 9635
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 5,
+            "isBeingKept": true,
+            "roadId": 11560
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 5,
+            "isBeingKept": true,
+            "roadId": 9290
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8612
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 23272
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8699
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 21655
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11245
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22886
+        },
+        {
+            "pixelSize": 7,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10927
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9213
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22606
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22109
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8521
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9172
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 21735
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22442
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 21763
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8721
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 21933
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22713
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8614
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 10299
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8683
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22248
+        },
+        {
+            "pixelSize": 6,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9771
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22640
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22782
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 9814
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9608
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11366
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9281
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22187
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8819
+        },
+        {
+            "pixelSize": 5,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9783
+        },
+        {
+            "pixelSize": 4,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 22410
+        },
+        {
+            "pixelSize": 4,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 11475
+        },
+        {
+            "pixelSize": 4,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 8813
+        },
+        {
+            "pixelSize": 4,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 9217
+        },
+        {
+            "pixelSize": 3,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 23234
+        },
+        {
+            "pixelSize": 3,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 19409
+        },
+        {
+            "pixelSize": 3,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 9632
+        },
+        {
+            "pixelSize": 3,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 18021
+        },
+        {
+            "pixelSize": 2,
+            "pixelUniqueContribution": 1,
+            "isBeingKept": false,
+            "roadId": 8920
+        },
+        {
+            "pixelSize": 1,
+            "pixelUniqueContribution": 0,
+            "isBeingKept": false,
+            "roadId": 19479
+        }
+    ]
+}

--- a/Assets/Dedupes/Ann Arbor.dedupe.json.meta
+++ b/Assets/Dedupes/Ann Arbor.dedupe.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 60808d797faf7d64aa2d694a4c7406b2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/RoadDuplicationDetector.unity
+++ b/Assets/Scenes/RoadDuplicationDetector.unity
@@ -1,0 +1,502 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!29 &1
+OcclusionCullingSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_OcclusionBakeSettings:
+    smallestOccluder: 5
+    smallestHole: 0.25
+    backfaceThreshold: 100
+  m_SceneGUID: 00000000000000000000000000000000
+  m_OcclusionCullingData: {fileID: 0}
+--- !u!104 &2
+RenderSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 9
+  m_Fog: 0
+  m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
+  m_FogMode: 3
+  m_FogDensity: 0.01
+  m_LinearFogStart: 0
+  m_LinearFogEnd: 300
+  m_AmbientSkyColor: {r: 0.212, g: 0.227, b: 0.259, a: 1}
+  m_AmbientEquatorColor: {r: 0.114, g: 0.125, b: 0.133, a: 1}
+  m_AmbientGroundColor: {r: 0.047, g: 0.043, b: 0.035, a: 1}
+  m_AmbientIntensity: 1
+  m_AmbientMode: 3
+  m_SubtractiveShadowColor: {r: 0.42, g: 0.478, b: 0.627, a: 1}
+  m_SkyboxMaterial: {fileID: 0}
+  m_HaloStrength: 0.5
+  m_FlareStrength: 1
+  m_FlareFadeSpeed: 3
+  m_HaloTexture: {fileID: 0}
+  m_SpotCookie: {fileID: 10001, guid: 0000000000000000e000000000000000, type: 0}
+  m_DefaultReflectionMode: 0
+  m_DefaultReflectionResolution: 128
+  m_ReflectionBounces: 1
+  m_ReflectionIntensity: 1
+  m_CustomReflection: {fileID: 0}
+  m_Sun: {fileID: 0}
+  m_IndirectSpecularColor: {r: 0, g: 0, b: 0, a: 1}
+  m_UseRadianceAmbientProbe: 0
+--- !u!157 &3
+LightmapSettings:
+  m_ObjectHideFlags: 0
+  serializedVersion: 11
+  m_GIWorkflowMode: 1
+  m_GISettings:
+    serializedVersion: 2
+    m_BounceScale: 1
+    m_IndirectOutputScale: 1
+    m_AlbedoBoost: 1
+    m_EnvironmentLightingMode: 0
+    m_EnableBakedLightmaps: 0
+    m_EnableRealtimeLightmaps: 0
+  m_LightmapEditorSettings:
+    serializedVersion: 12
+    m_Resolution: 2
+    m_BakeResolution: 40
+    m_AtlasSize: 1024
+    m_AO: 0
+    m_AOMaxDistance: 1
+    m_CompAOExponent: 1
+    m_CompAOExponentDirect: 0
+    m_ExtractAmbientOcclusion: 0
+    m_Padding: 2
+    m_LightmapParameters: {fileID: 0}
+    m_LightmapsBakeMode: 1
+    m_TextureCompression: 1
+    m_FinalGather: 0
+    m_FinalGatherFiltering: 1
+    m_FinalGatherRayCount: 256
+    m_ReflectionCompression: 2
+    m_MixedBakeMode: 2
+    m_BakeBackend: 1
+    m_PVRSampling: 1
+    m_PVRDirectSampleCount: 32
+    m_PVRSampleCount: 512
+    m_PVRBounces: 2
+    m_PVREnvironmentSampleCount: 256
+    m_PVREnvironmentReferencePointCount: 2048
+    m_PVRFilteringMode: 1
+    m_PVRDenoiserTypeDirect: 1
+    m_PVRDenoiserTypeIndirect: 1
+    m_PVRDenoiserTypeAO: 1
+    m_PVRFilterTypeDirect: 0
+    m_PVRFilterTypeIndirect: 0
+    m_PVRFilterTypeAO: 0
+    m_PVREnvironmentMIS: 1
+    m_PVRCulling: 1
+    m_PVRFilteringGaussRadiusDirect: 1
+    m_PVRFilteringGaussRadiusIndirect: 5
+    m_PVRFilteringGaussRadiusAO: 2
+    m_PVRFilteringAtrousPositionSigmaDirect: 0.5
+    m_PVRFilteringAtrousPositionSigmaIndirect: 2
+    m_PVRFilteringAtrousPositionSigmaAO: 1
+    m_ExportTrainingData: 0
+    m_TrainingDataDestination: TrainingData
+    m_LightProbeSampleCountMultiplier: 4
+  m_LightingDataAsset: {fileID: 0}
+  m_UseShadowmask: 1
+--- !u!196 &4
+NavMeshSettings:
+  serializedVersion: 2
+  m_ObjectHideFlags: 0
+  m_BuildSettings:
+    serializedVersion: 2
+    agentTypeID: 0
+    agentRadius: 0.5
+    agentHeight: 2
+    agentSlope: 45
+    agentClimb: 0.4
+    ledgeDropHeight: 0
+    maxJumpAcrossDistance: 0
+    minRegionArea: 2
+    manualCellSize: 0
+    cellSize: 0.16666667
+    manualTileSize: 0
+    tileSize: 256
+    accuratePlacement: 0
+    debug:
+      m_Flags: 0
+  m_NavMeshData: {fileID: 0}
+--- !u!1 &160104943
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 160104946}
+  - component: {fileID: 160104945}
+  m_Layer: 0
+  m_Name: Texture Camera
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!20 &160104945
+Camera:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160104943}
+  m_Enabled: 0
+  serializedVersion: 2
+  m_ClearFlags: 1
+  m_BackGroundColor: {r: 0.19215687, g: 0.3019608, b: 0.4745098, a: 0}
+  m_projectionMatrixMode: 1
+  m_GateFitMode: 2
+  m_FOVAxisMode: 0
+  m_SensorSize: {x: 36, y: 24}
+  m_LensShift: {x: 0, y: 0}
+  m_FocalLength: 50
+  m_NormalizedViewPortRect:
+    serializedVersion: 2
+    x: 0
+    y: 0
+    width: 1
+    height: 1
+  near clip plane: 0.3
+  far clip plane: 1000
+  field of view: 60
+  orthographic: 0
+  orthographic size: 5
+  m_Depth: 0
+  m_CullingMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RenderingPath: -1
+  m_TargetTexture: {fileID: 0}
+  m_TargetDisplay: 0
+  m_TargetEye: 3
+  m_HDR: 1
+  m_AllowMSAA: 1
+  m_AllowDynamicResolution: 0
+  m_ForceIntoRT: 0
+  m_OcclusionCulling: 1
+  m_StereoConvergence: 10
+  m_StereoSeparation: 0.022
+--- !u!4 &160104946
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 160104943}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 888.7778, y: 178.6632, z: -113.75}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &189732822 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4920497640028693817, guid: 21166c92722572a4894703f716e61b8c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2018051915}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e7d390a34d08fe2418ca86b02c085638, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!1 &403382763 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 6318903299560662670, guid: 21166c92722572a4894703f716e61b8c,
+    type: 3}
+  m_PrefabInstance: {fileID: 2018051915}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &403382764
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 403382763}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: db68132a0a9146d2bf2c22c5eb33e3d6, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  potholePrefab: {fileID: 8956065939585700126, guid: 6da3ac45e6cac414a945615c60dd2616,
+    type: 3}
+  roads: []
+  contextMenuControler: {fileID: 189732822}
+  textureCamera: {fileID: 160104945}
+--- !u!1001 &2018051915
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1271797627241702706, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_Name
+      value: BaseScene
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797627241702709, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1271797628247567618, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: potholeController
+      value: 
+      objectReference: {fileID: 403382764}
+    - target: {fileID: 2045570438879295814, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2045570438879295814, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2045570438879295814, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2045570438879295814, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2045570438879295814, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2045570438879295814, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836770348354795214, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836770348354795214, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836770348354795214, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836770348354795214, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836770348354795214, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3836770348354795214, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178173252458574380, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178173252458574380, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178173252458574380, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178173252458574380, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178173252458574380, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5178173252458574380, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6742483916042448608, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6742483916042448608, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6742483916042448608, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6742483916042448608, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6742483916042448608, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6742483916042448608, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6982154905219026904, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6982154905219026904, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6982154905219026904, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6982154905219026904, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6982154905219026904, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6982154905219026904, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7377049806577948147, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7377049806577948147, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7377049806577948147, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7377049806577948147, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7377049806577948147, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7377049806577948147, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8259893182675192528, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_BackGroundColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8259893182675192528, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_BackGroundColor.g
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8259893182675192528, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: m_BackGroundColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents:
+    - {fileID: 216195350906039678, guid: 21166c92722572a4894703f716e61b8c, type: 3}
+  m_SourcePrefab: {fileID: 100100000, guid: 21166c92722572a4894703f716e61b8c, type: 3}

--- a/Assets/Scenes/RoadDuplicationDetector.unity.meta
+++ b/Assets/Scenes/RoadDuplicationDetector.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 54e345db101e78e438e11eef451e0f42
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/Road.cs
+++ b/Assets/Scripts/Data/Road.cs
@@ -47,6 +47,8 @@ public class Road : MonoBehaviour
     [HideInInspector]
     public PlaythroughStatistics playthroughStatistics;
 
+    protected Bounds bounds;
+    
     private LineRenderer lineRenderer;
     private ParticleSystem _particleSystem;
     private bool _selected = false;
@@ -378,6 +380,7 @@ public class Road : MonoBehaviour
         // Fill linerenderer with points
         lineRenderer.widthMultiplier = lanes * roadWidthMultiplier;
         lineRenderer.positionCount = pline.NumPoints;
+        bounds = new Bounds();
         for (int j = 0; j < pline.Points.Length; j++)
         {
             Assets.Point p = pline.Points[j];
@@ -388,6 +391,8 @@ public class Road : MonoBehaviour
             MaxY = Mathf.Max(MaxY, v.y);
             MinX = Mathf.Min(MinX, v.x);
             MinY = Mathf.Min(MinY, v.y);
+
+            this.updateBounds(v);
         }
         lineRenderer.SetPositions(points.ToArray());
 
@@ -421,6 +426,18 @@ public class Road : MonoBehaviour
         _editableShape.mesh = mesh;
     }
 
+    private void updateBounds(Vector3 newPoint)
+    {
+        if (bounds.center.Equals(Vector3.zero) && bounds.extents.Equals(Vector3.zero))
+        {
+            bounds = new Bounds(newPoint, Vector3.zero);
+        }
+        else
+        {
+            bounds.Encapsulate(newPoint);
+        }
+    }
+
     public Vector3 RandomPoint()
     {
         int randIdx = new System.Random().Next(points.Count - 1);
@@ -449,5 +466,10 @@ public class Road : MonoBehaviour
     public static int Sort(Road r1, Road r2)
     {
         return r1.trafficSum.CompareTo(r2.trafficSum);
+    }
+
+    public Bounds GetBounds()
+    {
+        return this.bounds;
     }
 }

--- a/Assets/Scripts/Data/Road.cs
+++ b/Assets/Scripts/Data/Road.cs
@@ -472,4 +472,9 @@ public class Road : MonoBehaviour
     {
         return this.bounds;
     }
+
+    public void Render(bool render)
+    {
+        this.lineRenderer.enabled = render;
+    }
 }

--- a/Assets/Scripts/JsonHelper.cs
+++ b/Assets/Scripts/JsonHelper.cs
@@ -1,0 +1,31 @@
+using System;
+using UnityEngine;
+
+public static class JsonHelper
+{
+    public static T[] FromJson<T>(string json)
+    {
+        Wrapper<T> wrapper = JsonUtility.FromJson<Wrapper<T>>(json);
+        return wrapper.Items;
+    }
+
+    public static string ToJson<T>(T[] array)
+    {
+        Wrapper<T> wrapper = new Wrapper<T>();
+        wrapper.Items = array;
+        return JsonUtility.ToJson(wrapper);
+    }
+
+    public static string ToJson<T>(T[] array, bool prettyPrint)
+    {
+        Wrapper<T> wrapper = new Wrapper<T>();
+        wrapper.Items = array;
+        return JsonUtility.ToJson(wrapper, prettyPrint);
+    }
+
+    [Serializable]
+    private class Wrapper<T>
+    {
+        public T[] Items;
+    }
+}

--- a/Assets/Scripts/JsonHelper.cs.meta
+++ b/Assets/Scripts/JsonHelper.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b293ab9c290b4570b3768f2116d4d4d8
+timeCreated: 1611425175

--- a/Assets/Scripts/PotholeController.cs
+++ b/Assets/Scripts/PotholeController.cs
@@ -17,7 +17,7 @@ public class PotholeController : MonoBehaviour
     private GameObject _potholeParent;
     private BalanceParameters _parameters;
 
-    private double _sumTraffic = 0;
+    protected double _sumTraffic = 0;
     
     void Start()
     {
@@ -83,7 +83,7 @@ public class PotholeController : MonoBehaviour
         ageEnumerator = null;
     }
 
-    public void SortAndSumRoads()
+    public virtual void SortAndSumRoads()
     {
         roads.Sort(Road.Sort);
         foreach (Road road in roads )

--- a/Assets/Scripts/RoadDedupingPotholeController.cs
+++ b/Assets/Scripts/RoadDedupingPotholeController.cs
@@ -1,13 +1,146 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
 using UnityEngine;
+using UnityEngine.Experimental.Rendering;
+using UnityEngine.UIElements;
 
 namespace DefaultNamespace
 {
     public class RoadDedupingPotholeController : PotholeController
     {
+        private List<LineRenderer> _roadLineRenderers;
+        public Camera textureCamera;
+
         public override void SortAndSumRoads()
         {
             base.SortAndSumRoads();
-            Debug.Log("Deduping roads...");
+            DeDupeRoads();
+        }
+
+        void Update()
+        {
+            if (Input.GetKeyUp(KeyCode.Slash))
+            {
+                DeDupeRoads();
+            }
+        }
+
+        private void DeDupeRoads()
+        {
+            this._roadLineRenderers = GameObject.Find("Roads").GetComponentsInChildren<LineRenderer>().ToList();
+            InitializeTextureCamera();
+            /*for(int i = 0; i < this.roads.Count; i++){
+                for (int j = i + 1; j < this.roads.Count; j++)
+                {
+                    CheckRoadDuplication(this.roads[i], this.roads[j]);
+                    if(i*j >= 100) return;
+                }
+            }*/
+            CheckRoadDuplication(roads[2], roads[3]);
+            CheckRoadDuplication(roads[0], roads[1]);
+
+            //DestroyTextureCamera();
+        }
+
+        private void DestroyTextureCamera()
+        {
+            Destroy(textureCamera.targetTexture);
+            Destroy(textureCamera);
+        }
+
+        private RenderTexture InitializeTextureCamera()
+        {
+            textureCamera.CopyFrom(Camera.main);
+            RenderTexture renderTexture = new RenderTexture(Screen.width, Screen.height, 24);
+            textureCamera.targetTexture = renderTexture;
+            return renderTexture;
+        }
+
+        private void CheckRoadDuplication(Road road, Road other)
+        {
+            Texture2D imageRoad = getImageOfRoad(road);
+            Debug.Log("Nonwhite pixels in road1 image: " + countPixelsNotOfColor(imageRoad, Color.white) + ", total " + imageRoad.GetPixels().Length);
+            Texture2D imageOther = getImageOfRoad(other);
+            Debug.Log("Nonwhite pixels in road2 image: " + countPixelsNotOfColor(imageOther, Color.white) + ", total " + imageOther.GetPixels().Length);
+            Debug.Log("Number of nonwhite pixels in common: " + countPixelsNotOfColorInCommon(imageRoad, imageOther, Color.white));
+            Debug.Log("Recommendation: " + getRoadCollisionRecommendation(countPixelsNotOfColor(imageRoad, Color.white), countPixelsNotOfColor(imageOther, Color.white), countPixelsNotOfColorInCommon(imageRoad, imageOther, Color.white)));
+        }
+
+        private int countPixelsNotOfColorInCommon(Texture2D image, Texture2D other, Color exclusionColor)
+        {
+            int inCommon = 0;
+            Color[] imagePixels = image.GetPixels();
+            Color[] otherPixels = other.GetPixels();
+            for (int i = 0; i < imagePixels.Length; i++)
+            {
+                if (imagePixels[i] == otherPixels[i] && imagePixels[i] != exclusionColor)
+                {
+                    inCommon++;
+                }
+            }
+
+            return inCommon;
+        }
+
+        private String getRoadCollisionRecommendation(int relevantPixelCountImageOne, int relevantPixelCountImageTwo, int sizeInCommon)
+        {
+            if (sizeInCommon <= 0)
+            {
+                return "NO_ACTION";
+            }
+            else if (sizeInCommon >= relevantPixelCountImageOne)
+            {
+                return "REMOVE_FIRST_ROAD";
+            }
+            else if(sizeInCommon >= relevantPixelCountImageTwo)
+            {
+                return "REMOVE_SECOND_ROAD";
+            }
+            else
+            {
+                //there is overlap but neither road is 100% covered by the other
+                return "STUDY_FURTHER";
+            }
+        }
+
+        private int countPixelsNotOfColor(Texture2D texture, Color color)
+        {
+            return texture.GetPixels().Count(pixel => pixel != color);
+        }
+
+        private Texture2D getImageOfRoad(Road road)
+        {
+            enableOnlyOneLineRenderer(road);
+            textureCamera.Render();
+            return TakeImageFromCamera(textureCamera);
+        }
+
+        private void enableOnlyOneLineRenderer(Road toRender)
+        {
+            foreach (LineRenderer lineRenderer in this._roadLineRenderers)
+            {
+                lineRenderer.enabled = false;
+            }
+
+            toRender.GetComponentInChildren<LineRenderer>().enabled = true;
+        }
+        
+        // Take a "screenshot" of a camera's Render Texture.
+        Texture2D TakeImageFromCamera(Camera camera)
+        {
+            var savedRT = RenderTexture.active;
+            RenderTexture.active = camera.targetTexture;
+
+            camera.Render();
+
+            Texture2D image = new Texture2D(camera.targetTexture.width, camera.targetTexture.height, TextureFormat.RGB24, false);
+            image.ReadPixels(new Rect(0, 0, camera.targetTexture.width, camera.targetTexture.height), 0, 0);
+            image.Apply();
+
+            RenderTexture.active = savedRT;
+            return image;
         }
     }
 }

--- a/Assets/Scripts/RoadDedupingPotholeController.cs
+++ b/Assets/Scripts/RoadDedupingPotholeController.cs
@@ -103,7 +103,7 @@ public class RoadDedupingPotholeController : PotholeController
 
     private void PrintRoadIdWhitelist(List<RoadDeduplicationMetadata> dedupeResult)
     {
-        System.IO.File.WriteAllText(FindObjectOfType<ShapefileImport>().city+".dedupe.json",
+        System.IO.File.WriteAllText("Assets/Dedupes/" + FindObjectOfType<ShapefileImport>().city+".dedupe.json",
             JsonHelper.ToJson(dedupeResult.Select(getCopyForWriting).ToArray(),
                 true));
     }

--- a/Assets/Scripts/RoadDedupingPotholeController.cs
+++ b/Assets/Scripts/RoadDedupingPotholeController.cs
@@ -32,7 +32,6 @@ namespace DefaultNamespace
                 Texture2D imageRoad = getImageOfRoad(roadsToDedupe[i]);
                 for (int j = i + 1; j < roadsToDedupe.Count; j++)
                 {
-                    Debug.Log("I: " + i + " J: " + j);
                     if (checkBoundsIntersection(roadsToDedupe[i], roadsToDedupe[j]))
                     {
                         Texture2D imageOther = getImageOfRoad(roadsToDedupe[j]);
@@ -42,16 +41,15 @@ namespace DefaultNamespace
                     yield return null;
                 }
                 Destroy(imageRoad);
+                Debug.Log("Road " + i + " dedupe finished.");
             }
             DestroyTextureCamera();
         }
 
         private static bool checkBoundsIntersection(Road road, Road other)
         {
-            Debug.Log("Road bounds: " + road.GetBounds() + " , Road2 Bounds: " + other.GetBounds());
-            bool intersects = road.GetBounds().Intersects(other.GetBounds());
-            Debug.Log("Returning " + intersects + " at bounds intersection test");
-            return intersects;
+            return road.GetBounds().Intersects(other.GetBounds());
+            //consider using Colliders instead, since roads come with those
         }
 
         private void DestroyTextureCamera()

--- a/Assets/Scripts/RoadDedupingPotholeController.cs
+++ b/Assets/Scripts/RoadDedupingPotholeController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -16,32 +17,41 @@ namespace DefaultNamespace
         public override void SortAndSumRoads()
         {
             base.SortAndSumRoads();
-            DeDupeRoads();
+            StartCoroutine(DeDupeRoads(this.roads));
         }
 
         void Update()
         {
-            if (Input.GetKeyUp(KeyCode.Slash))
-            {
-                DeDupeRoads();
-            }
         }
 
-        private void DeDupeRoads()
+        private IEnumerator DeDupeRoads(List<Road> roadsToDedupe)
         {
             this._roadLineRenderers = GameObject.Find("Roads").GetComponentsInChildren<LineRenderer>().ToList();
             InitializeTextureCamera();
-            /*for(int i = 0; i < this.roads.Count; i++){
-                for (int j = i + 1; j < this.roads.Count; j++)
+            for(int i = 0; i < roadsToDedupe.Count; i++){
+                Texture2D imageRoad = getImageOfRoad(roadsToDedupe[i]);
+                for (int j = i + 1; j < roadsToDedupe.Count; j++)
                 {
-                    CheckRoadDuplication(this.roads[i], this.roads[j]);
-                    if(i*j >= 100) return;
+                    Debug.Log("I: " + i + " J: " + j);
+                    if (checkBoundsIntersection(roadsToDedupe[i], roadsToDedupe[j]))
+                    {
+                        Texture2D imageOther = getImageOfRoad(roadsToDedupe[j]);
+                        CheckImageCollision(imageRoad, imageOther);
+                        Destroy(imageOther);
+                    } 
+                    yield return null;
                 }
-            }*/
-            CheckRoadDuplication(roads[2], roads[3]);
-            CheckRoadDuplication(roads[0], roads[1]);
+                Destroy(imageRoad);
+            }
+            DestroyTextureCamera();
+        }
 
-            //DestroyTextureCamera();
+        private static bool checkBoundsIntersection(Road road, Road other)
+        {
+            Debug.Log("Road bounds: " + road.GetBounds() + " , Road2 Bounds: " + other.GetBounds());
+            bool intersects = road.GetBounds().Intersects(other.GetBounds());
+            Debug.Log("Returning " + intersects + " at bounds intersection test");
+            return intersects;
         }
 
         private void DestroyTextureCamera()
@@ -58,11 +68,9 @@ namespace DefaultNamespace
             return renderTexture;
         }
 
-        private void CheckRoadDuplication(Road road, Road other)
+        private void CheckImageCollision(Texture2D imageRoad, Texture2D imageOther)
         {
-            Texture2D imageRoad = getImageOfRoad(road);
             Debug.Log("Nonwhite pixels in road1 image: " + countPixelsNotOfColor(imageRoad, Color.white) + ", total " + imageRoad.GetPixels().Length);
-            Texture2D imageOther = getImageOfRoad(other);
             Debug.Log("Nonwhite pixels in road2 image: " + countPixelsNotOfColor(imageOther, Color.white) + ", total " + imageOther.GetPixels().Length);
             Debug.Log("Number of nonwhite pixels in common: " + countPixelsNotOfColorInCommon(imageRoad, imageOther, Color.white));
             Debug.Log("Recommendation: " + getRoadCollisionRecommendation(countPixelsNotOfColor(imageRoad, Color.white), countPixelsNotOfColor(imageOther, Color.white), countPixelsNotOfColorInCommon(imageRoad, imageOther, Color.white)));
@@ -113,7 +121,6 @@ namespace DefaultNamespace
         private Texture2D getImageOfRoad(Road road)
         {
             enableOnlyOneLineRenderer(road);
-            textureCamera.Render();
             return TakeImageFromCamera(textureCamera);
         }
 

--- a/Assets/Scripts/RoadDedupingPotholeController.cs
+++ b/Assets/Scripts/RoadDedupingPotholeController.cs
@@ -11,6 +11,15 @@ namespace DefaultNamespace
 {
     public class RoadDedupingPotholeController : PotholeController
     {
+
+        private struct RoadDeduplicationMetadata
+        {
+            public int pixelSize;
+            public int pixelUniqueContribution;
+            public bool isBeingKept;
+            public Road road;
+        }
+
         private List<LineRenderer> _roadLineRenderers;
         public Camera textureCamera;
 
@@ -23,8 +32,146 @@ namespace DefaultNamespace
         void Update()
         {
         }
-
+        
         private IEnumerator DeDupeRoads(List<Road> roadsToDedupe)
+        {
+            //first loop: pixel size each road alone
+            //second loop: all roads so far, compared with all roads so far plus the ith road
+            float ratioThatGetsYouAPass = 0.5f;
+            List<RoadDeduplicationMetadata> dedupeResult = new List<RoadDeduplicationMetadata>(roadsToDedupe.Count);
+            //pixel size of roads
+            disableRoadRenderers(roadsToDedupe);
+            InitializeTextureCamera();
+            Texture2D imageRoad = Texture2D.whiteTexture;
+            for (int i = 0; i < roadsToDedupe.Count; i++)
+            {
+                roadsToDedupe[i].Render(true);
+                imageRoad = TakeImageFromCamera(textureCamera);
+                RoadDeduplicationMetadata roadDeduplicationMetadata = new RoadDeduplicationMetadata();
+                roadDeduplicationMetadata.pixelSize = countPixelsNotOfColor(imageRoad, Color.white);
+                roadDeduplicationMetadata.road = roadsToDedupe[i];
+                dedupeResult.Add(roadDeduplicationMetadata);
+                roadsToDedupe[i].Render(false);
+                Debug.Log("Road " + i + " of " + roadsToDedupe.Count + " imaging finished, size: " + dedupeResult[i].pixelSize);
+                yield return null;
+            }
+            Destroy(imageRoad);
+            //unique contribution of each road to the map of unexcluded roads
+            dedupeResult.Sort((m1, m2) => m2.pixelSize.CompareTo(m1.pixelSize));
+            disableRoadRenderers(roadsToDedupe);
+            Texture2D imageAllRoads = Texture2D.whiteTexture;
+            Texture2D imageAllRoadsPlusJth = Texture2D.whiteTexture;
+            for (int j = 0; j < dedupeResult.Count; j++)
+            {
+                imageAllRoads = TakeImageFromCamera(textureCamera);
+                dedupeResult[j].road.Render(true);
+                imageAllRoadsPlusJth = TakeImageFromCamera(textureCamera);
+                RoadDeduplicationMetadata jthRoadDeduplicationMetadata = dedupeResult[j];
+                jthRoadDeduplicationMetadata.pixelUniqueContribution = (countPixelsNotOfColor(imageAllRoadsPlusJth, Color.white) -
+                                                countPixelsNotOfColor(imageAllRoads, Color.white));
+
+                jthRoadDeduplicationMetadata.isBeingKept = (jthRoadDeduplicationMetadata.pixelUniqueContribution != 0 &&
+                                  (float) jthRoadDeduplicationMetadata.pixelUniqueContribution / jthRoadDeduplicationMetadata.pixelSize > ratioThatGetsYouAPass);
+                if (!jthRoadDeduplicationMetadata.isBeingKept)
+                {
+                    dedupeResult[j].road.Render(false);
+                }
+                Debug.Log("Road "+ j + " of " + dedupeResult.Count + " unique pixels: " + jthRoadDeduplicationMetadata.pixelUniqueContribution + " and total size: " + jthRoadDeduplicationMetadata.pixelSize + ", conclusion: " + (jthRoadDeduplicationMetadata.isBeingKept ? "keeping" : "discarding"));
+                yield return null;
+            }
+
+            EvaluateDedupe(imageAllRoads, dedupeResult);
+            PrintRoadIdWhitelist(dedupeResult);
+            Destroy(imageAllRoads);
+            Destroy(imageAllRoadsPlusJth);
+            DestroyTextureCamera();
+        }
+
+        private void PrintRoadIdWhitelist(List<RoadDeduplicationMetadata> dedupeResult)
+        {
+            IEnumerable<int> whitelistedRoadIds = dedupeResult.Where(result => result.isBeingKept).Select(result => result.road.ID);
+            string ids = string.Join(",", whitelistedRoadIds);
+            Debug.Log(ids);
+        }
+
+        private IEnumerator DeDupeRoadsSubtractively(List<Road> roadsToDedupe)
+        {
+            //first loop: pixel size of roads
+            //second loop: all roads so far, compared with all roads so far minus the ith road
+            //This subtractive algorithm says 0 unique pixels for every single road.  I believe this means every road has an exact duplicate.
+            int sizeThatGetsYouAPass = 100;
+            float ratioThatGetsYouAPass = 0.5f;
+            
+            disableRoadRenderers(roadsToDedupe);
+            List<int> roadSizesPixels = new List<int>(roadsToDedupe.Count);
+            List<int> roadUniqueContributionsPixels = new List<int>(roadsToDedupe.Count);
+            List<bool> isRoadBeingKept = new List<bool>(roadsToDedupe.Count);
+            //pixel size of roads
+            InitializeTextureCamera();
+            Texture2D imageRoad = Texture2D.whiteTexture;
+            for (int i = 0; i < roadsToDedupe.Count; i++)
+            {
+                roadsToDedupe[i].Render(true);
+                imageRoad = TakeImageFromCamera(textureCamera);
+                roadSizesPixels.Add(countPixelsNotOfColor(imageRoad, Color.white));
+                roadsToDedupe[i].Render(false);
+                Debug.Log("Road " + i + " of " + roadsToDedupe.Count + " imaging finished, size: " + roadSizesPixels[i]);
+                yield return null;
+            }
+            Destroy(imageRoad);
+            //unique contribution of each road to the map of unexcluded roads
+            enableRoadRenderers(roadsToDedupe);
+            Texture2D imageAllRoads = Texture2D.whiteTexture;
+            Texture2D imageAllRoadsMinusJth = Texture2D.whiteTexture;
+            for (int j = 0; j < roadsToDedupe.Count; j++)
+            {
+                imageAllRoads = TakeImageFromCamera(textureCamera);
+                roadsToDedupe[j].Render(false);
+                imageAllRoadsMinusJth = TakeImageFromCamera(textureCamera);
+                roadUniqueContributionsPixels.Add(countPixelsNotOfColor(imageAllRoads, Color.white) -
+                                                countPixelsNotOfColor(imageAllRoadsMinusJth, Color.white));
+               
+                isRoadBeingKept.Add(roadSizesPixels[j] > sizeThatGetsYouAPass || roadUniqueContributionsPixels[j] != 0 &&
+                                  (float) roadUniqueContributionsPixels[j] / roadSizesPixels[j] > ratioThatGetsYouAPass);
+                if (isRoadBeingKept[j])
+                {
+                    roadsToDedupe[j].Render(true);
+                }
+                Debug.Log("Road "+ j + " of " + roadsToDedupe.Count + " unique pixels: " + roadUniqueContributionsPixels[j] + " and total size: " + roadSizesPixels[j] + ", conclusion: " + (isRoadBeingKept[j] ? "keeping" : "discarding"));
+                yield return null;
+            }
+
+            EvaluateDedupe(imageAllRoads, new List<RoadDeduplicationMetadata>());
+            Destroy(imageAllRoads);
+            Destroy(imageAllRoadsMinusJth);
+            DestroyTextureCamera();
+        }
+
+        private void EvaluateDedupe(Texture2D dedupedRoadsImage, List<RoadDeduplicationMetadata> results)
+        {
+            int pixelsInDisabledRoads = results.Where(result => !result.isBeingKept).Sum(result => result.pixelSize);
+            int pixelsInDedupedImage = countPixelsNotOfColor(dedupedRoadsImage, Color.white);
+            enableRoadRenderers(roads);
+            Texture2D dupedUpRoadsImage = TakeImageFromCamera(textureCamera);
+            int pixelsInDupedImage = countPixelsNotOfColor(dupedUpRoadsImage, Color.white);
+            Debug.Log("duped roads total " + pixelsInDupedImage + "pixels; deduped " + pixelsInDedupedImage + "; " +
+                      (((float) pixelsInDedupedImage / pixelsInDupedImage) * 100) + "% accuracy");
+            Debug.Log(pixelsInDisabledRoads + " pixels' worth of roads disabled; " +(pixelsInDisabledRoads / pixelsInDedupedImage * 100) + "% of final map size");
+
+
+        }
+
+        private void enableRoadRenderers(List<Road> toEnable)
+        {
+             toEnable.ForEach(road => road.Render(true));
+        }
+
+        private void disableRoadRenderers(List<Road> toDisable)
+        {
+            toDisable.ForEach(road => road.Render(false));
+        }
+
+        private IEnumerator DeDupeRoadsNSquared(List<Road> roadsToDedupe)
         {
             this._roadLineRenderers = GameObject.Find("Roads").GetComponentsInChildren<LineRenderer>().ToList();
             InitializeTextureCamera();

--- a/Assets/Scripts/RoadDedupingPotholeController.cs
+++ b/Assets/Scripts/RoadDedupingPotholeController.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+namespace DefaultNamespace
+{
+    public class RoadDedupingPotholeController : PotholeController
+    {
+        public override void SortAndSumRoads()
+        {
+            base.SortAndSumRoads();
+            Debug.Log("Deduping roads...");
+        }
+    }
+}

--- a/Assets/Scripts/RoadDedupingPotholeController.cs
+++ b/Assets/Scripts/RoadDedupingPotholeController.cs
@@ -7,292 +7,179 @@ using UnityEngine;
 using UnityEngine.Experimental.Rendering;
 using UnityEngine.UIElements;
 
-namespace DefaultNamespace
+public class RoadDedupingPotholeController : PotholeController
 {
-    public class RoadDedupingPotholeController : PotholeController
+    private struct RoadDeduplicationMetadata
     {
+        public int pixelSize;
+        public int pixelUniqueContribution;
+        public bool isBeingKept;
+        public Road road;
+    }
 
-        private struct RoadDeduplicationMetadata
+    [Serializable]
+    private struct RoadDeduplicationWrittenData
+    {
+        public int pixelSize;
+        public int pixelUniqueContribution;
+        public bool isBeingKept;
+        public int roadId;
+    }
+
+    private List<LineRenderer> _roadLineRenderers;
+    public Camera textureCamera;
+    public float ratioThatGetsYouAPass = 0.5f;
+
+    public override void SortAndSumRoads()
+    {
+        base.SortAndSumRoads();
+        StartCoroutine(DeDupeRoads(this.roads));
+    }
+
+    void Update()
+    {
+    }
+
+    private IEnumerator DeDupeRoads(List<Road> roadsToDedupe)
+    {
+        //first loop: pixel size, each road alone
+        //sort by size desc
+        //second loop: pixel size, all roads so far, compared with all roads so far plus the ith road
+        List<RoadDeduplicationMetadata> dedupeResult = new List<RoadDeduplicationMetadata>(roadsToDedupe.Count);
+        //pixel size of roads
+        disableRoadRenderers(roadsToDedupe);
+        InitializeTextureCamera();
+        Texture2D imageRoad = Texture2D.whiteTexture;
+        for (int i = 0; i < roadsToDedupe.Count; i++)
         {
-            public int pixelSize;
-            public int pixelUniqueContribution;
-            public bool isBeingKept;
-            public Road road;
+            roadsToDedupe[i].Render(true);
+            imageRoad = TakeImageFromCamera(textureCamera);
+            RoadDeduplicationMetadata roadDeduplicationMetadata = new RoadDeduplicationMetadata();
+            roadDeduplicationMetadata.pixelSize = countPixelsNotOfColor(imageRoad, Color.white);
+            roadDeduplicationMetadata.road = roadsToDedupe[i];
+            dedupeResult.Add(roadDeduplicationMetadata);
+            roadsToDedupe[i].Render(false);
+            Debug.Log("Road " + i + " of " + roadsToDedupe.Count + " imaging finished, size: " +
+                      dedupeResult[i].pixelSize);
+            yield return null;
         }
 
-        private List<LineRenderer> _roadLineRenderers;
-        public Camera textureCamera;
+        Destroy(imageRoad);
+        //unique contribution of each road to the map of unexcluded roads
+        dedupeResult.Sort((m1, m2) => m2.pixelSize.CompareTo(m1.pixelSize));
+        disableRoadRenderers(roadsToDedupe);
+        Texture2D imageAllRoads = Texture2D.whiteTexture;
+        Texture2D imageAllRoadsPlusJth = Texture2D.whiteTexture;
+        for (int j = 0; j < dedupeResult.Count; j++)
+        {
+            imageAllRoads = TakeImageFromCamera(textureCamera);
+            dedupeResult[j].road.Render(true);
+            imageAllRoadsPlusJth = TakeImageFromCamera(textureCamera);
+            RoadDeduplicationMetadata jthRoadDeduplicationMetadata = dedupeResult[j];
+            jthRoadDeduplicationMetadata.pixelUniqueContribution =
+                (countPixelsNotOfColor(imageAllRoadsPlusJth, Color.white) -
+                 countPixelsNotOfColor(imageAllRoads, Color.white));
 
-        public override void SortAndSumRoads()
-        {
-            base.SortAndSumRoads();
-            StartCoroutine(DeDupeRoads(this.roads));
-        }
-
-        void Update()
-        {
-        }
-        
-        private IEnumerator DeDupeRoads(List<Road> roadsToDedupe)
-        {
-            //first loop: pixel size each road alone
-            //second loop: all roads so far, compared with all roads so far plus the ith road
-            float ratioThatGetsYouAPass = 0.5f;
-            List<RoadDeduplicationMetadata> dedupeResult = new List<RoadDeduplicationMetadata>(roadsToDedupe.Count);
-            //pixel size of roads
-            disableRoadRenderers(roadsToDedupe);
-            InitializeTextureCamera();
-            Texture2D imageRoad = Texture2D.whiteTexture;
-            for (int i = 0; i < roadsToDedupe.Count; i++)
+            jthRoadDeduplicationMetadata.isBeingKept = shouldKeepRoad(
+                jthRoadDeduplicationMetadata.pixelUniqueContribution, jthRoadDeduplicationMetadata.pixelSize);
+            if (!jthRoadDeduplicationMetadata.isBeingKept)
             {
-                roadsToDedupe[i].Render(true);
-                imageRoad = TakeImageFromCamera(textureCamera);
-                RoadDeduplicationMetadata roadDeduplicationMetadata = new RoadDeduplicationMetadata();
-                roadDeduplicationMetadata.pixelSize = countPixelsNotOfColor(imageRoad, Color.white);
-                roadDeduplicationMetadata.road = roadsToDedupe[i];
-                dedupeResult.Add(roadDeduplicationMetadata);
-                roadsToDedupe[i].Render(false);
-                Debug.Log("Road " + i + " of " + roadsToDedupe.Count + " imaging finished, size: " + dedupeResult[i].pixelSize);
-                yield return null;
-            }
-            Destroy(imageRoad);
-            //unique contribution of each road to the map of unexcluded roads
-            dedupeResult.Sort((m1, m2) => m2.pixelSize.CompareTo(m1.pixelSize));
-            disableRoadRenderers(roadsToDedupe);
-            Texture2D imageAllRoads = Texture2D.whiteTexture;
-            Texture2D imageAllRoadsPlusJth = Texture2D.whiteTexture;
-            for (int j = 0; j < dedupeResult.Count; j++)
-            {
-                imageAllRoads = TakeImageFromCamera(textureCamera);
-                dedupeResult[j].road.Render(true);
-                imageAllRoadsPlusJth = TakeImageFromCamera(textureCamera);
-                RoadDeduplicationMetadata jthRoadDeduplicationMetadata = dedupeResult[j];
-                jthRoadDeduplicationMetadata.pixelUniqueContribution = (countPixelsNotOfColor(imageAllRoadsPlusJth, Color.white) -
-                                                countPixelsNotOfColor(imageAllRoads, Color.white));
-
-                jthRoadDeduplicationMetadata.isBeingKept = (jthRoadDeduplicationMetadata.pixelUniqueContribution != 0 &&
-                                  (float) jthRoadDeduplicationMetadata.pixelUniqueContribution / jthRoadDeduplicationMetadata.pixelSize > ratioThatGetsYouAPass);
-                if (!jthRoadDeduplicationMetadata.isBeingKept)
-                {
-                    dedupeResult[j].road.Render(false);
-                }
-                Debug.Log("Road "+ j + " of " + dedupeResult.Count + " unique pixels: " + jthRoadDeduplicationMetadata.pixelUniqueContribution + " and total size: " + jthRoadDeduplicationMetadata.pixelSize + ", conclusion: " + (jthRoadDeduplicationMetadata.isBeingKept ? "keeping" : "discarding"));
-                yield return null;
+                dedupeResult[j].road.Render(false);
             }
 
-            EvaluateDedupe(imageAllRoads, dedupeResult);
-            PrintRoadIdWhitelist(dedupeResult);
-            Destroy(imageAllRoads);
-            Destroy(imageAllRoadsPlusJth);
-            DestroyTextureCamera();
+            dedupeResult[j] = jthRoadDeduplicationMetadata;
+            Debug.Log("Road " + j + " of " + dedupeResult.Count + " unique pixels: " +
+                      jthRoadDeduplicationMetadata.pixelUniqueContribution + " and total size: " +
+                      jthRoadDeduplicationMetadata.pixelSize + ", conclusion: " +
+                      (jthRoadDeduplicationMetadata.isBeingKept ? "keeping" : "discarding"));
+            yield return null;
         }
+        Destroy(imageAllRoads);
+        Destroy(imageAllRoadsPlusJth);
+        //EvaluateDedupe(dedupeResult);
+        PrintRoadIdWhitelist(dedupeResult);
+        DestroyTextureCamera();
+    }
 
-        private void PrintRoadIdWhitelist(List<RoadDeduplicationMetadata> dedupeResult)
-        {
-            IEnumerable<int> whitelistedRoadIds = dedupeResult.Where(result => result.isBeingKept).Select(result => result.road.ID);
-            string ids = string.Join(",", whitelistedRoadIds);
-            Debug.Log(ids);
-        }
+    private void PrintRoadIdWhitelist(List<RoadDeduplicationMetadata> dedupeResult)
+    {
+        System.IO.File.WriteAllText(FindObjectOfType<ShapefileImport>().city+".dedupe.json",
+            JsonHelper.ToJson(dedupeResult.Select(getCopyForWriting).ToArray(),
+                true));
+    }
 
-        private IEnumerator DeDupeRoadsSubtractively(List<Road> roadsToDedupe)
-        {
-            //first loop: pixel size of roads
-            //second loop: all roads so far, compared with all roads so far minus the ith road
-            //This subtractive algorithm says 0 unique pixels for every single road.  I believe this means every road has an exact duplicate.
-            int sizeThatGetsYouAPass = 100;
-            float ratioThatGetsYouAPass = 0.5f;
-            
-            disableRoadRenderers(roadsToDedupe);
-            List<int> roadSizesPixels = new List<int>(roadsToDedupe.Count);
-            List<int> roadUniqueContributionsPixels = new List<int>(roadsToDedupe.Count);
-            List<bool> isRoadBeingKept = new List<bool>(roadsToDedupe.Count);
-            //pixel size of roads
-            InitializeTextureCamera();
-            Texture2D imageRoad = Texture2D.whiteTexture;
-            for (int i = 0; i < roadsToDedupe.Count; i++)
-            {
-                roadsToDedupe[i].Render(true);
-                imageRoad = TakeImageFromCamera(textureCamera);
-                roadSizesPixels.Add(countPixelsNotOfColor(imageRoad, Color.white));
-                roadsToDedupe[i].Render(false);
-                Debug.Log("Road " + i + " of " + roadsToDedupe.Count + " imaging finished, size: " + roadSizesPixels[i]);
-                yield return null;
-            }
-            Destroy(imageRoad);
-            //unique contribution of each road to the map of unexcluded roads
-            enableRoadRenderers(roadsToDedupe);
-            Texture2D imageAllRoads = Texture2D.whiteTexture;
-            Texture2D imageAllRoadsMinusJth = Texture2D.whiteTexture;
-            for (int j = 0; j < roadsToDedupe.Count; j++)
-            {
-                imageAllRoads = TakeImageFromCamera(textureCamera);
-                roadsToDedupe[j].Render(false);
-                imageAllRoadsMinusJth = TakeImageFromCamera(textureCamera);
-                roadUniqueContributionsPixels.Add(countPixelsNotOfColor(imageAllRoads, Color.white) -
-                                                countPixelsNotOfColor(imageAllRoadsMinusJth, Color.white));
-               
-                isRoadBeingKept.Add(roadSizesPixels[j] > sizeThatGetsYouAPass || roadUniqueContributionsPixels[j] != 0 &&
-                                  (float) roadUniqueContributionsPixels[j] / roadSizesPixels[j] > ratioThatGetsYouAPass);
-                if (isRoadBeingKept[j])
-                {
-                    roadsToDedupe[j].Render(true);
-                }
-                Debug.Log("Road "+ j + " of " + roadsToDedupe.Count + " unique pixels: " + roadUniqueContributionsPixels[j] + " and total size: " + roadSizesPixels[j] + ", conclusion: " + (isRoadBeingKept[j] ? "keeping" : "discarding"));
-                yield return null;
-            }
+    /*private void EvaluateDedupe(List<RoadDeduplicationMetadata> results)
+    {
+        int pixelsInDisabledRoads = results.Where(result => !result.isBeingKept).Sum(result => result.pixelSize);
+        int pixelsInDedupedImage = countPixelsNotOfColor(dedupedRoadsImage, Color.white);
+        enableRoadRenderers(roads);
+        Texture2D dupedUpRoadsImage = TakeImageFromCamera(textureCamera);
+        int pixelsInDupedImage = countPixelsNotOfColor(dupedUpRoadsImage, Color.white);
+        Debug.Log("duped roads total " + pixelsInDupedImage + "pixels; deduped " + pixelsInDedupedImage + "; " +
+                  (((float) pixelsInDedupedImage / pixelsInDupedImage) * 100) + "% accuracy");
+        Debug.Log(pixelsInDisabledRoads + " pixels' worth of roads disabled; " +
+                  (pixelsInDisabledRoads / pixelsInDedupedImage * 100) + "% of final map size");
+    }*/
 
-            EvaluateDedupe(imageAllRoads, new List<RoadDeduplicationMetadata>());
-            Destroy(imageAllRoads);
-            Destroy(imageAllRoadsMinusJth);
-            DestroyTextureCamera();
-        }
+    private void enableRoadRenderers(List<Road> toEnable)
+    {
+        toEnable.ForEach(road => road.Render(true));
+    }
 
-        private void EvaluateDedupe(Texture2D dedupedRoadsImage, List<RoadDeduplicationMetadata> results)
-        {
-            int pixelsInDisabledRoads = results.Where(result => !result.isBeingKept).Sum(result => result.pixelSize);
-            int pixelsInDedupedImage = countPixelsNotOfColor(dedupedRoadsImage, Color.white);
-            enableRoadRenderers(roads);
-            Texture2D dupedUpRoadsImage = TakeImageFromCamera(textureCamera);
-            int pixelsInDupedImage = countPixelsNotOfColor(dupedUpRoadsImage, Color.white);
-            Debug.Log("duped roads total " + pixelsInDupedImage + "pixels; deduped " + pixelsInDedupedImage + "; " +
-                      (((float) pixelsInDedupedImage / pixelsInDupedImage) * 100) + "% accuracy");
-            Debug.Log(pixelsInDisabledRoads + " pixels' worth of roads disabled; " +(pixelsInDisabledRoads / pixelsInDedupedImage * 100) + "% of final map size");
+    private void disableRoadRenderers(List<Road> toDisable)
+    {
+        toDisable.ForEach(road => road.Render(false));
+    }
 
+    private void DestroyTextureCamera()
+    {
+        Destroy(textureCamera.targetTexture);
+        Destroy(textureCamera);
+    }
 
-        }
+    private RenderTexture InitializeTextureCamera()
+    {
+        textureCamera.CopyFrom(Camera.main);
+        RenderTexture renderTexture = new RenderTexture(Screen.width, Screen.height, 24);
+        textureCamera.targetTexture = renderTexture;
+        return renderTexture;
+    }
 
-        private void enableRoadRenderers(List<Road> toEnable)
-        {
-             toEnable.ForEach(road => road.Render(true));
-        }
+    private bool shouldKeepRoad(int uniqueContributionPixels, int totalPixels)
+    {
+        return uniqueContributionPixels != 0 &&
+               (float) uniqueContributionPixels / totalPixels > ratioThatGetsYouAPass;
+    }
 
-        private void disableRoadRenderers(List<Road> toDisable)
-        {
-            toDisable.ForEach(road => road.Render(false));
-        }
+    private int countPixelsNotOfColor(Texture2D texture, Color color)
+    {
+        return texture.GetPixels().Count(pixel => pixel != color);
+    }
 
-        private IEnumerator DeDupeRoadsNSquared(List<Road> roadsToDedupe)
-        {
-            this._roadLineRenderers = GameObject.Find("Roads").GetComponentsInChildren<LineRenderer>().ToList();
-            InitializeTextureCamera();
-            for(int i = 0; i < roadsToDedupe.Count; i++){
-                Texture2D imageRoad = getImageOfRoad(roadsToDedupe[i]);
-                for (int j = i + 1; j < roadsToDedupe.Count; j++)
-                {
-                    if (checkBoundsIntersection(roadsToDedupe[i], roadsToDedupe[j]))
-                    {
-                        Texture2D imageOther = getImageOfRoad(roadsToDedupe[j]);
-                        CheckImageCollision(imageRoad, imageOther);
-                        Destroy(imageOther);
-                    } 
-                    yield return null;
-                }
-                Destroy(imageRoad);
-                Debug.Log("Road " + i + " dedupe finished.");
-            }
-            DestroyTextureCamera();
-        }
+    RoadDeduplicationWrittenData getCopyForWriting(RoadDeduplicationMetadata data)
+    {
+        var toReturn = new RoadDeduplicationWrittenData();
+        toReturn.roadId = data.road.ID;
+        toReturn.pixelSize = data.pixelSize;
+        toReturn.isBeingKept = data.isBeingKept;
+        toReturn.pixelUniqueContribution = data.pixelUniqueContribution;
+        return toReturn;
+    }
 
-        private static bool checkBoundsIntersection(Road road, Road other)
-        {
-            return road.GetBounds().Intersects(other.GetBounds());
-            //consider using Colliders instead, since roads come with those
-        }
+    // Take a "screenshot" of a camera's Render Texture.
+    Texture2D TakeImageFromCamera(Camera camera)
+    {
+        var savedRT = RenderTexture.active;
+        RenderTexture.active = camera.targetTexture;
 
-        private void DestroyTextureCamera()
-        {
-            Destroy(textureCamera.targetTexture);
-            Destroy(textureCamera);
-        }
+        camera.Render();
 
-        private RenderTexture InitializeTextureCamera()
-        {
-            textureCamera.CopyFrom(Camera.main);
-            RenderTexture renderTexture = new RenderTexture(Screen.width, Screen.height, 24);
-            textureCamera.targetTexture = renderTexture;
-            return renderTexture;
-        }
+        Texture2D image = new Texture2D(camera.targetTexture.width, camera.targetTexture.height, TextureFormat.RGB24,
+            false);
+        image.ReadPixels(new Rect(0, 0, camera.targetTexture.width, camera.targetTexture.height), 0, 0);
+        image.Apply();
 
-        private void CheckImageCollision(Texture2D imageRoad, Texture2D imageOther)
-        {
-            Debug.Log("Nonwhite pixels in road1 image: " + countPixelsNotOfColor(imageRoad, Color.white) + ", total " + imageRoad.GetPixels().Length);
-            Debug.Log("Nonwhite pixels in road2 image: " + countPixelsNotOfColor(imageOther, Color.white) + ", total " + imageOther.GetPixels().Length);
-            Debug.Log("Number of nonwhite pixels in common: " + countPixelsNotOfColorInCommon(imageRoad, imageOther, Color.white));
-            Debug.Log("Recommendation: " + getRoadCollisionRecommendation(countPixelsNotOfColor(imageRoad, Color.white), countPixelsNotOfColor(imageOther, Color.white), countPixelsNotOfColorInCommon(imageRoad, imageOther, Color.white)));
-        }
-
-        private int countPixelsNotOfColorInCommon(Texture2D image, Texture2D other, Color exclusionColor)
-        {
-            int inCommon = 0;
-            Color[] imagePixels = image.GetPixels();
-            Color[] otherPixels = other.GetPixels();
-            for (int i = 0; i < imagePixels.Length; i++)
-            {
-                if (imagePixels[i] == otherPixels[i] && imagePixels[i] != exclusionColor)
-                {
-                    inCommon++;
-                }
-            }
-
-            return inCommon;
-        }
-
-        private String getRoadCollisionRecommendation(int relevantPixelCountImageOne, int relevantPixelCountImageTwo, int sizeInCommon)
-        {
-            if (sizeInCommon <= 0)
-            {
-                return "NO_ACTION";
-            }
-            else if (sizeInCommon >= relevantPixelCountImageOne)
-            {
-                return "REMOVE_FIRST_ROAD";
-            }
-            else if(sizeInCommon >= relevantPixelCountImageTwo)
-            {
-                return "REMOVE_SECOND_ROAD";
-            }
-            else
-            {
-                //there is overlap but neither road is 100% covered by the other
-                return "STUDY_FURTHER";
-            }
-        }
-
-        private int countPixelsNotOfColor(Texture2D texture, Color color)
-        {
-            return texture.GetPixels().Count(pixel => pixel != color);
-        }
-
-        private Texture2D getImageOfRoad(Road road)
-        {
-            enableOnlyOneLineRenderer(road);
-            return TakeImageFromCamera(textureCamera);
-        }
-
-        private void enableOnlyOneLineRenderer(Road toRender)
-        {
-            foreach (LineRenderer lineRenderer in this._roadLineRenderers)
-            {
-                lineRenderer.enabled = false;
-            }
-
-            toRender.GetComponentInChildren<LineRenderer>().enabled = true;
-        }
-        
-        // Take a "screenshot" of a camera's Render Texture.
-        Texture2D TakeImageFromCamera(Camera camera)
-        {
-            var savedRT = RenderTexture.active;
-            RenderTexture.active = camera.targetTexture;
-
-            camera.Render();
-
-            Texture2D image = new Texture2D(camera.targetTexture.width, camera.targetTexture.height, TextureFormat.RGB24, false);
-            image.ReadPixels(new Rect(0, 0, camera.targetTexture.width, camera.targetTexture.height), 0, 0);
-            image.Apply();
-
-            RenderTexture.active = savedRT;
-            return image;
-        }
+        RenderTexture.active = savedRT;
+        return image;
     }
 }

--- a/Assets/Scripts/RoadDedupingPotholeController.cs.meta
+++ b/Assets/Scripts/RoadDedupingPotholeController.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: db68132a0a9146d2bf2c22c5eb33e3d6
+timeCreated: 1611029895

--- a/Assets/Scripts/ShapefileImport.cs
+++ b/Assets/Scripts/ShapefileImport.cs
@@ -77,9 +77,8 @@ public class ShapefileImport : MonoBehaviour
             }
         }
 
-        potholeController.SortAndSumRoads();
-
         configureMainCamera();
+        potholeController.SortAndSumRoads();
         Debug.Log("Done.");
     }
 

--- a/Assets/Scripts/ShapefileImport.cs
+++ b/Assets/Scripts/ShapefileImport.cs
@@ -5,6 +5,7 @@ using System.IO;
 using UnityEngine;
 using UnityEditor;
 using System;
+using Assets;
 using UnityEngine.UI;
 
 public class ShapefileImport : MonoBehaviour
@@ -65,17 +66,7 @@ public class ShapefileImport : MonoBehaviour
                 // Some records aren't polyline and I don't know what they're for
                 if (record.ShpRecord.Header.Type == Assets.ShapeType.PolyLine)
                 {
-                    GameObject roadObj = Instantiate(roadPrefab, new Vector3(0, 0, 0), Quaternion.identity, roadParent.transform);
-                    Road road = roadObj.GetComponent<Road>();
-                    road.roadWidthMultiplier = roadWidthMultiplier;
-                    road.loadFromGIS(record);
-                    if (road.isValid)
-                    {
-                        potholeController.roads.Add(road);
-                        road.balanceParameters = balanceParameters;
-                        road.contextMenuController = contextMenuController;
-                        road.playthroughStatistics = playthroughStatistics;
-                    }
+                    createRoad(record, roadParent.transform);
                 }
                 if (count > linesPerFrame)
                 {
@@ -88,9 +79,30 @@ public class ShapefileImport : MonoBehaviour
 
         potholeController.SortAndSumRoads();
 
-        Camera.main.gameObject.GetComponent<CameraController>().JumpTo(new Vector3((Road.MaxX + Road.MinX) * 0.5f, (Road.MaxY + Road.MinY) * 0.5f, -10f));
+        configureMainCamera();
+        Debug.Log("Done.");
+    }
+
+    private void configureMainCamera()
+    {
+        Camera.main.gameObject.GetComponent<CameraController>()
+            .JumpTo(new Vector3((Road.MaxX + Road.MinX) * 0.5f, (Road.MaxY + Road.MinY) * 0.5f, -10f));
         float maxExtent = Mathf.Max(Road.MaxX - Road.MinX, Road.MaxY - Road.MinY);
         Camera.main.orthographicSize = maxExtent * 0.5f + cameraMargin;
-        Debug.Log("Done.");
+    }
+
+    private void createRoad(GISRecord record, Transform parent)
+    {
+        GameObject roadObj = Instantiate(roadPrefab, new Vector3(0, 0, 0), Quaternion.identity, parent);
+        Road road = roadObj.GetComponent<Road>();
+        road.roadWidthMultiplier = roadWidthMultiplier;
+        road.loadFromGIS(record);
+        if (road.isValid)
+        {
+            potholeController.roads.Add(road);
+            road.balanceParameters = balanceParameters;
+            road.contextMenuController = contextMenuController;
+            road.playthroughStatistics = playthroughStatistics;
+        }
     }
 }


### PR DESCRIPTION
Merge in a scene and special pothole controller with the ability to eliminate roads that are at least X% duplicates of some other set of roads on the map, according to the roads' silhouettes.  Output is placed in Assets/Dedupes by city name, with one json file meant for consumption by the level and one a report on the performance of the deduper.