### PR TITLE
Balance Hamtramck around low labor and high patch cost

### DIFF
--- a/Assets/Autoplaythroughs/Hamtramck-091fd545-dd2e-4d62-a092-36ee9ce35b4a.json
+++ b/Assets/Autoplaythroughs/Hamtramck-091fd545-dd2e-4d62-a092-36ee9ce35b4a.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 10,
+    "finalYear": 2,
+    "gameResult": "LOSS",
+    "strategyUsed": "Throw 'n' Roll every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 1064.7017822265625,
+    "finalBudget": 46155.0,
+    "finalLabor": 100.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-091fd545-dd2e-4d62-a092-36ee9ce35b4a.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-091fd545-dd2e-4d62-a092-36ee9ce35b4a.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1d3c1699bc01d0043b7583268b642583
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-6e920a64-7395-4711-935d-528e18e811c4.json
+++ b/Assets/Autoplaythroughs/Hamtramck-6e920a64-7395-4711-935d-528e18e811c4.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 8,
+    "finalYear": 2,
+    "gameResult": "LOSS",
+    "strategyUsed": "Throw 'n' Roll every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 1145.092041015625,
+    "finalBudget": 65275.0,
+    "finalLabor": 50.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-6e920a64-7395-4711-935d-528e18e811c4.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-6e920a64-7395-4711-935d-528e18e811c4.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 474fbef82a22703409f399b76ecb2c8b
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-78a3746a-3754-45e7-907e-c3d4f3c1aac2.json
+++ b/Assets/Autoplaythroughs/Hamtramck-78a3746a-3754-45e7-907e-c3d4f3c1aac2.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 1,
+    "finalYear": 5,
+    "gameResult": "BAD_WIN",
+    "strategyUsed": "Asphalt Patch every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 282.8487243652344,
+    "finalBudget": 148750.0,
+    "finalLabor": 0.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-78a3746a-3754-45e7-907e-c3d4f3c1aac2.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-78a3746a-3754-45e7-907e-c3d4f3c1aac2.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7243d4df16cecf947a2fb8577828013e
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-9129d673-3201-475f-aac8-1c824723bfb9.json
+++ b/Assets/Autoplaythroughs/Hamtramck-9129d673-3201-475f-aac8-1c824723bfb9.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 1,
+    "finalYear": 6,
+    "gameResult": "GOOD_WIN",
+    "strategyUsed": "Asphalt Patch every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 835.3554077148438,
+    "finalBudget": 105000.0,
+    "finalLabor": 60.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-9129d673-3201-475f-aac8-1c824723bfb9.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-9129d673-3201-475f-aac8-1c824723bfb9.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6a25e47ff8e624f4fbc247fe3fa89347
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-944f2d93-ab38-4fbd-aa4b-e41c309b558c.json
+++ b/Assets/Autoplaythroughs/Hamtramck-944f2d93-ab38-4fbd-aa4b-e41c309b558c.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 7,
+    "finalYear": 3,
+    "gameResult": "LOSS",
+    "strategyUsed": "Throw 'n' Roll every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 1090.66650390625,
+    "finalBudget": 95775.0,
+    "finalLabor": 50.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-944f2d93-ab38-4fbd-aa4b-e41c309b558c.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-944f2d93-ab38-4fbd-aa4b-e41c309b558c.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 01d4348843ec18743b3a9bdf019e10e1
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-bdf3c16a-0861-496b-bd86-cd916dfae35a.json
+++ b/Assets/Autoplaythroughs/Hamtramck-bdf3c16a-0861-496b-bd86-cd916dfae35a.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 1,
+    "finalYear": 6,
+    "gameResult": "GOOD_WIN",
+    "strategyUsed": "Asphalt Patch every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 825.6420288085938,
+    "finalBudget": 120531.859375,
+    "finalLabor": 10.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-bdf3c16a-0861-496b-bd86-cd916dfae35a.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-bdf3c16a-0861-496b-bd86-cd916dfae35a.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 46bcf8fee9ccbf1439f1ff625a66c70d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-c9731aec-2d17-4240-9c6d-ae3f4388b5e3.json
+++ b/Assets/Autoplaythroughs/Hamtramck-c9731aec-2d17-4240-9c6d-ae3f4388b5e3.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 10,
+    "finalYear": 5,
+    "gameResult": "LOSS",
+    "strategyUsed": "Asphalt Patch every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 1113.5316162109375,
+    "finalBudget": 139250.0,
+    "finalLabor": 20.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-c9731aec-2d17-4240-9c6d-ae3f4388b5e3.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-c9731aec-2d17-4240-9c6d-ae3f4388b5e3.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 99db567c565b2214597441a60d2cadbb
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-f120d3e4-6b0c-48f8-b07d-0b8b3b76e933.json
+++ b/Assets/Autoplaythroughs/Hamtramck-f120d3e4-6b0c-48f8-b07d-0b8b3b76e933.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 1,
+    "finalYear": 6,
+    "gameResult": "GOOD_WIN",
+    "strategyUsed": "Asphalt Patch every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 463.02056884765627,
+    "finalBudget": 110000.0,
+    "finalLabor": 10.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-f120d3e4-6b0c-48f8-b07d-0b8b3b76e933.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-f120d3e4-6b0c-48f8-b07d-0b8b3b76e933.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 1f76ebe844de7e0419061337eea2d257
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-f65ef294-fdb3-461f-89b8-4a2653382b0e.json
+++ b/Assets/Autoplaythroughs/Hamtramck-f65ef294-fdb3-461f-89b8-4a2653382b0e.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 5,
+    "finalYear": 3,
+    "gameResult": "LOSS",
+    "strategyUsed": "Throw 'n' Roll every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 1032.0736083984375,
+    "finalBudget": 71540.0,
+    "finalLabor": 100.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-f65ef294-fdb3-461f-89b8-4a2653382b0e.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-f65ef294-fdb3-461f-89b8-4a2653382b0e.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7c77621c92f859f4b9a076fc03fc13c2
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Autoplaythroughs/Hamtramck-f737bc6b-4c38-4727-8b53-047f4fc1910e.json
+++ b/Assets/Autoplaythroughs/Hamtramck-f737bc6b-4c38-4727-8b53-047f4fc1910e.json
@@ -1,0 +1,9 @@
+{
+    "finalMonth": 4,
+    "finalYear": 5,
+    "gameResult": "LOSS",
+    "strategyUsed": "Asphalt Patch every open pothole until out of money.  Never resurface roads, ever",
+    "finalAnger": 1127.3328857421875,
+    "finalBudget": 148750.0,
+    "finalLabor": 40.0
+}

--- a/Assets/Autoplaythroughs/Hamtramck-f737bc6b-4c38-4727-8b53-047f4fc1910e.json.meta
+++ b/Assets/Autoplaythroughs/Hamtramck-f737bc6b-4c38-4727-8b53-047f4fc1910e.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b51c3263e66cda040a620297c7f08e6f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Cities/Hamtramck.unity
+++ b/Assets/Scenes/Cities/Hamtramck.unity
@@ -265,18 +265,23 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
+      propertyPath: maxLabor
+      value: 50
+      objectReference: {fileID: 0}
+    - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
       propertyPath: maxYears
       value: 5
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
       propertyPath: moneyToWin
-      value: 300000
+      value: 140000
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
       propertyPath: budgetPerYear
-      value: 50000
+      value: 40000
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
@@ -310,8 +315,13 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
+      propertyPath: minimumPotholePatchDuration
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
       propertyPath: roadConstructionAngerPerCar
-      value: 10
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
@@ -331,17 +341,17 @@ PrefabInstance:
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
       propertyPath: potholeRepairs.Array.data[0].cost
-      value: 350
+      value: 425
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
       propertyPath: potholeRepairs.Array.data[1].cost
-      value: 355
+      value: 450
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
       propertyPath: potholeRepairs.Array.data[2].cost
-      value: 1000
+      value: 1350
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
@@ -351,12 +361,17 @@ PrefabInstance:
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
       propertyPath: potholeRepairs.Array.data[3].cost
-      value: 1250
+      value: 1500
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}
       propertyPath: potholeRepairs.Array.data[3].time
       value: 5
+      objectReference: {fileID: 0}
+    - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
+        type: 3}
+      propertyPath: potholeRepairs.Array.data[4].cost
+      value: 25
       objectReference: {fileID: 0}
     - target: {fileID: 5101476513431392859, guid: 21166c92722572a4894703f716e61b8c,
         type: 3}


### PR DESCRIPTION
Hamtramck is meant to exaggerate a little bit the benefit of concrete resurfacing and concrete patching relative to other methods.  However, with a low labor and money budget, these choices will hopefully require some experimentation and not be immediately intuitive.